### PR TITLE
Requesting for merging changes to feature/rccs_intern branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,5 @@ stdout.*
 stderr.*
 
 #
+model/atm_nonhydro3d/test/rccs_intern/**
 model/atm_nonhydro3d/test/case/**/*.nc

--- a/FElib/src/common/scale_sparsemat_orig.F90
+++ b/FElib/src/common/scale_sparsemat_orig.F90
@@ -1,0 +1,505 @@
+#include "scaleFElib.h"
+module scale_sparsemat
+  !-----------------------------------------------------------------------------
+  !
+  !++ used modules
+  !
+  use scale_precision
+  use scale_io
+  use scale_prc
+  use scale_const, only:    &
+    UNDEF8 => CONST_UNDEF8, &
+    CONST_EPS
+  
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public type & procedure
+  !  
+
+  type, public :: sparsemat
+    integer :: M                      !< Number of row of original matrix
+    integer :: N                      !< Number of column of original matrix
+    integer :: nnz                    !< Number of nonzero of the matrix
+    real(RP), allocatable :: val(:)   !< Array storing the values of the nonzeros
+    integer, allocatable :: colIdx(:) !< Array saving the column indices of the nonzeros
+
+    ! for CSR format
+    integer, allocatable :: rowPtr(:) !< Array saving the start and end pointers of the nonzeros of the rows.
+    integer :: rowPtrSize             !< Size of rowPtr
+
+    ! for ELL format
+    integer :: col_size
+
+    integer, private :: storage_format_id      !< Number of row of original matrix
+  contains
+    procedure, public :: Init => sparsemat_Init
+    procedure, public :: Final => sparsemat_Final
+    procedure, public :: Print => sparsemat_Print
+    procedure, public :: ReplaceVal => sparsemat_ReplceVal
+    procedure, public :: GetVal => sparsemat_GetVal
+    procedure, public :: GetStorageFormatId => sparsemat_get_storage_format_id
+  end type sparsemat
+
+  interface sparsemat_matmul
+    module procedure sparsemat_matmul1
+    module procedure sparsemat_matmul2
+  end interface
+  public :: sparsemat_matmul
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public parameters & variables
+  !
+  integer, public, parameter :: SPARSEMAT_STORAGE_TYPEID_CSR = 1
+  integer, public, parameter :: SPARSEMAT_STORAGE_TYPEID_ELL = 2
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedure
+  !
+  private :: sparsemat_matmul_CSR_1
+  private :: sparsemat_matmul_CSR_2
+  private :: sparsemat_matmul_ELL_1
+  private :: sparsemat_matmul_ELL_2
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private parameters & variables
+  !
+  
+  !-----------------------------------------------------------------------------
+
+contains
+  subroutine sparsemat_Init( this, mat, &
+      EPS, storage_format )
+    implicit none
+
+    class(SparseMat), intent(inout) :: this
+    real(RP), intent(in) :: mat(:,:)
+    real(RP), optional, intent(in) :: EPS
+    character(len=*), optional, intent(in) :: storage_format
+
+    integer :: i
+    integer :: j
+    integer :: l
+
+    integer :: val_counter
+    integer :: rowptr_counter
+    
+    real(DP) :: tmp_val(size(mat)+1)
+    integer :: tmp_colInd(size(mat)+1)
+    integer :: tmp_rowptr(0:size(mat,1)+1)
+
+    real(RP) :: EPS_
+    character(len=H_MID) :: storage_format_ = 'CSR' 
+
+    integer :: row_nonzero_counter(size(mat,1))
+    integer :: col_size_l
+
+    !--------------------------------------------------------------------------- 
+ 
+    this%M = size(mat,1)
+    this%N = size(mat,2)
+
+    val_counter     = 1
+    rowptr_counter  = 1
+    tmp_rowptr(1)   = 1
+    tmp_val(:)      = 0.0_RP
+
+    if (present(EPS)) then
+      EPS_ = EPS
+    else
+      EPS_ = CONST_EPS * 500.0_RP ! ~ 1x10^-13
+    end if
+
+    if (present(storage_format)) then
+      storage_format_ = storage_format
+    end if
+
+    select case (storage_format_)
+    case ('CSR')
+      this%storage_format_id = SPARSEMAT_STORAGE_TYPEID_CSR
+
+      do i=1, this%M
+        do j=1, this%N
+          if ( abs(mat(i,j)) > EPS_ ) then
+            tmp_val(val_counter) = mat(i,j)
+            tmp_colInd(val_counter) = j
+            val_counter = val_counter + 1
+          end if
+        end do
+        rowptr_counter = rowptr_counter + 1
+        tmp_rowptr(rowptr_counter) = val_counter
+      end do
+    case ('ELL')
+      this%storage_format_id = SPARSEMAT_STORAGE_TYPEID_ELL
+
+      do i=1, this%M
+        row_nonzero_counter(i) = 0
+        do j=1, this%N
+          if ( abs(mat(i,j)) > EPS_ ) &
+            row_nonzero_counter(i) = row_nonzero_counter(i) + 1
+        end do
+      end do
+      this%col_size = maxval(row_nonzero_counter(:))
+      val_counter   = this%M * this%col_size
+
+      tmp_val(:)    = 0.0_RP
+      tmp_colInd(:) = -1
+      do i=1, this%M
+        col_size_l = 0
+        do j=1,this%N
+          if ( abs(mat(i,j)) > EPS_ ) then
+              col_size_l = col_size_l + 1
+              l = i+(col_size_l-1)*this%M
+              tmp_val   (l) = mat(i,j)   
+              tmp_colInd(l) = j
+          end if
+        end do
+      end do
+    case default
+      LOG_ERROR("SparseMat_Init",*) 'Not appropriate names of storage format. Check!', trim(storage_format_)
+      call PRC_abort
+    end select
+
+    this%nnz = val_counter
+    allocate( this%val(val_counter) )
+    allocate( this%colIdx(val_counter) )
+    this%val(:)    = tmp_val   (1:val_counter)
+    this%colIdx(:) = tmp_colInd(1:val_counter)
+
+    select case (storage_format_)
+    case ('CSR')
+      allocate( this%rowPtr(rowptr_counter) )
+      this%rowPtr(:) = tmp_rowptr(1:rowptr_counter)
+      this%rowPtrSize = rowptr_counter
+    case('ELL')
+      do l=2, val_counter
+        if (this%colIdx(l) == -1) then
+          this%colIdx(l) = this%colIdx(l-1)
+        end if
+      end do
+    end select
+
+    !write(*,*) "--- Mat ------"
+    !write(*,*) "shape:", shape(mat)
+    !write(*,*) "size:", size(mat)
+    ! do j=1, size(mat,2)
+    !    write(*,*) mat(:,j)
+    ! end do
+    !write(*,*) "--- Compressed Mat ------"
+    !write(*,*) "shape (Mat, colInd, rowPtr):", &
+    !  & shape(this%val), shape(this%colInd), shape(this%rowPtr)
+    ! write(*,*) "val:", this%val(:)
+    ! write(*,*) "colInd:", this%colInd(:)
+    ! write(*,*) "rowPtr:", this%rowPtr(:)
+
+    return
+  end subroutine sparsemat_Init
+
+  subroutine sparsemat_Final(this)
+    implicit none
+    class(SparseMat), intent(inout) :: this
+
+    !--------------------------------------------------------------------------- 
+
+    deallocate( this%val )
+    deallocate( this%colIdx )
+
+    select case( this%storage_format_id )
+    case( SPARSEMAT_STORAGE_TYPEID_CSR )
+      deallocate( this%rowPtr )
+    end select
+
+    return
+  end subroutine sparsemat_Final
+
+  function sparsemat_GetVal(A, i, j) result(v)
+    class(sparsemat), intent(in) :: A
+    integer, intent(in) :: i, j
+
+    real(DP) ::v
+    integer :: n
+    integer :: jj
+    !--------------------------------------------------------------------------- 
+
+    v = UNDEF8
+    select case( A%storage_format_id )
+    case( SPARSEMAT_STORAGE_TYPEID_CSR )
+      do n=A%rowPtr(i),A%rowPtr(i+1)-1
+        if (A%colIdx(n) == j) then
+          v = A%val(n); exit
+        end if
+      end do
+    case ( SPARSEMAT_STORAGE_TYPEID_ELL )
+      do jj=1, A%col_size
+        n = i + (jj-1)*A%M
+        if (A%colIdx(n) == j) then
+          v = A%val(n); exit
+        end if
+      end do
+    end select
+
+    return
+  end function sparsemat_GetVal
+
+  subroutine sparsemat_ReplceVal(A, i, j, v)
+    
+    class(sparsemat), intent(inout) :: A
+    integer, intent(in) :: i, j
+    real(RP), intent(in) ::v
+
+    integer :: n
+    integer :: jj
+    !--------------------------------------------------------------------------- 
+
+    select case ( A%storage_format_id )
+    case ( SPARSEMAT_STORAGE_TYPEID_CSR )
+      do n=A%rowPtr(i),A%rowPtr(i+1)-1
+        if (A%colIdx(n) == j) then
+          A%val(n) = v; exit
+        end if
+      end do
+    case ( SPARSEMAT_STORAGE_TYPEID_ELL )
+      do jj=1, A%col_size
+        n = i + (jj-1)*A%M
+        if (A%colIdx(n) == j) then
+          A%val(n) = v; exit
+        end if
+      end do
+    end select
+
+    return
+  end subroutine sparsemat_ReplceVal
+
+  subroutine sparsemat_print(A)
+    implicit none
+    class(sparsemat), intent(in) :: A
+
+    real(RP) :: row_val(A%N)
+    integer :: p
+    integer :: j1, j2
+    !--------------------------------------------------------------------------- 
+
+    write(*,*) "-- print matrix:"
+    write(*,'(a,i5,a,i5)') "orginal matrix shape:", A%M, 'x', A%N
+    write(*,'(a,i5)') "size of compressed matrix:", A%nnz
+    select case ( A%storage_format_id )
+    case ( SPARSEMAT_STORAGE_TYPEID_CSR )
+      write(*,*) "rowPtr:", A%rowPtr(:)
+    end select
+    write(*,*) "colInd:", A%colIdx(:)
+    write(*,*) "val:"
+
+    select case ( A%storage_format_id )
+    case ( SPARSEMAT_STORAGE_TYPEID_CSR )
+      j1 = A%rowPtr(1)
+      do p=1, A%rowPtrSize-1
+        j2 = A%rowPtr(p+1)
+        row_val(:) = 0.0_RP
+        row_val(A%colIdx(j1:j2-1)) = A%val(j1:j2-1)
+        write(*,*) row_val(:)
+        j1 = j2
+      end do
+    case ( SPARSEMAT_STORAGE_TYPEID_ELL )
+      do p=1, A%M
+        row_val(:) = 0.0_RP
+        do j1=1, A%col_size
+          j2 = p + (j1-1)*A%M
+         row_val(A%colIdx(j2)) = A%val(j2)
+        end do
+        write(*,*) row_val(:)
+      end do
+    end select
+
+    return
+  end subroutine sparsemat_print
+
+  function sparsemat_get_storage_format_id( A ) result(id)
+    implicit none
+    class(sparsemat), intent(in) :: A
+    real(RP) :: id
+    !------------------------------------------------------
+
+    id = A%storage_format_id
+    return 
+  end function sparsemat_get_storage_format_id
+
+!OCL SERIAL  
+  subroutine sparsemat_matmul1(A, b, c)
+    implicit none
+
+    type(sparsemat), intent(in) :: A
+    real(RP), intent(in ) :: b(:)
+    real(RP), intent(out) :: c(A%M)
+
+    !--------------------------------------------------------------------------- 
+
+    select case( A%storage_format_id )
+    case( SPARSEMAT_STORAGE_TYPEID_CSR )
+      call sparsemat_matmul_CSR_1( A%val, A%colIdx, A%rowPtr, b, c, &
+        A%M, A%N, A%nnz, A%rowPtrSize                          )
+    case( SPARSEMAT_STORAGE_TYPEID_ELL )
+      call sparsemat_matmul_ELL_1( A%val, A%colIdx, b, c,           &
+        A%M, A%N, A%nnz, A%col_size                            )
+    end select
+
+    return
+  end subroutine sparsemat_matmul1
+
+!OCL SERIAL  
+  subroutine sparsemat_matmul2(A, b, c)
+    implicit none
+
+    type(sparsemat), intent(in) :: A
+    real(RP), intent(in ) :: b(:,:)
+    real(RP), intent(out) :: c(size(b,1),A%M)
+
+    !--------------------------------------------------------------------------- 
+
+    select case( A%storage_format_id )
+    case( SPARSEMAT_STORAGE_TYPEID_CSR )
+      call sparsemat_matmul_CSR_2( A%val, A%colIdx, A%rowPtr, b, c, &
+        A%M, A%N, A%nnz, A%rowPtrSize, size(b,1)               )
+    case( SPARSEMAT_STORAGE_TYPEID_ELL )
+      call sparsemat_matmul_ELL_2( A%val, A%colIdx, b, c,           &
+        A%M, A%N, A%nnz, A%col_size, size(b,1)                 )
+    end select
+
+    return
+  end subroutine sparsemat_matmul2
+
+!--- private ----------------------------------------------
+
+!OCL SERIAL
+  subroutine sparsemat_matmul_CSR_1(A, col_Ind, rowPtr, b, c, M, N, buf_size, rowPtr_size)
+    implicit none
+
+    integer, intent(in) :: M
+    integer, intent(in) :: N
+    integer, intent(in) :: buf_size
+    integer, intent(in) :: rowPtr_size
+    real(RP), intent(in) :: A(buf_size)
+    integer, intent(in) :: col_Ind(buf_size)
+    integer, intent(in) :: rowPtr(rowPtr_size)
+    real(RP), intent(in ) :: b(N)
+    real(RP), intent(out) :: c(M)
+
+    integer :: p, j
+    integer :: j1, j2
+
+    !--------------------------------------------------------------------------- 
+
+    !call mkl_dcsrgemv( 'N', rowPtr_size-1, A, rowPtr, col_Ind, b, c)
+    j1 = rowPtr(1)
+    do p=1, rowPtr_size-1
+       j2 = rowPtr(p+1) 
+       c(p) = 0.0_RP
+       do j=j1, j2-1
+          c(p) = c(p) + A(j) * b(col_Ind(j))
+       end do
+       j1 = j2
+    end do
+
+    return
+  end subroutine sparsemat_matmul_CSR_1
+
+!OCL SERIAL
+  subroutine sparsemat_matmul_CSR_2(A, col_Ind, rowPtr, b, c, M, N, buf_size, rowPtr_size, NQ)
+    implicit none
+
+    integer, intent(in) :: M
+    integer, intent(in) :: N
+    integer, intent(in) :: NQ
+    integer, intent(in) :: buf_size
+    integer, intent(in) :: rowPtr_size
+    real(RP), intent(in) :: A(buf_size)
+    integer, intent(in) :: col_Ind(buf_size)
+    integer, intent(in) :: rowPtr(rowPtr_size)
+    real(RP), intent(in ) :: b(NQ,N)
+    real(RP), intent(out) :: c(NQ,M)
+
+    integer :: p, j
+    integer :: j1, j2
+
+    !--------------------------------------------------------------------------- 
+
+    !call mkl_dcsrgemv( 'N', rowPtr_size-1, A, rowPtr, col_Ind, b, c)
+    j1 = rowPtr(1)
+    c(:,:) = 0.0_RP
+    do p=1, rowPtr_size-1
+      j2 = rowPtr(p+1) 
+      do j=j1, j2-1
+        c(:,p) = c(:,p) + A(j) * b(:,col_Ind(j))
+      end do
+      j1 = j2
+    end do
+
+    return
+  end subroutine sparsemat_matmul_CSR_2
+
+!OCL SERIAL
+  subroutine sparsemat_matmul_ELL_1(A, col_Ind, b, c, M, N, buf_size, col_size)
+    implicit none
+
+    integer, intent(in) :: M
+    integer, intent(in) :: N
+    integer, intent(in) :: buf_size
+    integer, intent(in) :: col_size
+    real(RP), intent(in) :: A(buf_size)
+    integer, intent(in) :: col_Ind(buf_size)
+    real(RP), intent(in ) :: b(N)
+    real(RP), intent(out) :: c(M)
+
+    integer :: k, kk, i
+    integer :: j_ptr
+    !--------------------------------------------------------------------------- 
+
+    c(:) = 0.0_RP
+    do k=1, col_size
+      kk = M * (k-1)
+      do i=1, M
+        j_ptr = kk + i        
+        c(i) = c(i) + A(j_ptr) * b(col_Ind(j_ptr))
+      end do
+    end do
+
+    return
+  end subroutine sparsemat_matmul_ELL_1
+
+!OCL SERIAL
+  subroutine sparsemat_matmul_ELL_2(A, col_Ind, b, c, M, N, buf_size, col_size, NQ)
+    implicit none
+
+    integer, intent(in) :: M
+    integer, intent(in) :: N
+    integer, intent(in) :: buf_size
+    integer, intent(in) :: col_size
+    integer, intent(in) :: NQ
+    real(RP), intent(in) :: A(buf_size)
+    integer, intent(in) :: col_Ind(buf_size)
+    real(RP), intent(in ) :: b(NQ,N)
+    real(RP), intent(out) :: c(NQ,M)
+
+    integer :: k, kk, i
+    integer :: j_ptr
+    !--------------------------------------------------------------------------- 
+
+    c(:,:) = 0.0_RP
+    do k=1, col_size
+      kk = M * (k-1)
+      do i=1, M
+        j_ptr = kk + i        
+        c(:,i) = c(:,i) + A(j_ptr) * b(:,col_Ind(j_ptr))
+      end do
+    end do
+
+    return
+  end subroutine sparsemat_matmul_ELL_2
+
+end module scale_sparsemat
+

--- a/FElib/src/common/scale_sparsemat_tune1.F90
+++ b/FElib/src/common/scale_sparsemat_tune1.F90
@@ -1,0 +1,592 @@
+#include "scaleFElib.h"
+module scale_sparsemat
+  !-----------------------------------------------------------------------------
+  !
+  !++ used modules
+  !
+  use scale_precision
+  use scale_io
+  use scale_prc
+  use scale_const, only:    &
+    UNDEF8 => CONST_UNDEF8, &
+    CONST_EPS
+  
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public type & procedure
+  !  
+
+  type, public :: sparsemat
+    integer :: M                      !< Number of row of original matrix
+    integer :: N                      !< Number of column of original matrix
+    integer :: nnz                    !< Number of nonzero of the matrix
+    real(RP), allocatable :: val(:)   !< Array storing the values of the nonzeros
+    integer, allocatable :: colIdx(:) !< Array saving the column indices of the nonzeros
+
+    ! for CSR format
+    integer, allocatable :: rowPtr(:) !< Array saving the start and end pointers of the nonzeros of the rows.
+    integer :: rowPtrSize             !< Size of rowPtr
+
+    ! for ELL format
+    integer :: col_size
+
+    integer, private :: storage_format_id      !< Number of row of original matrix
+  contains
+    procedure, public :: Init => sparsemat_Init
+    procedure, public :: Final => sparsemat_Final
+    procedure, public :: Print => sparsemat_Print
+    procedure, public :: ReplaceVal => sparsemat_ReplceVal
+    procedure, public :: GetVal => sparsemat_GetVal
+    procedure, public :: GetStorageFormatId => sparsemat_get_storage_format_id
+  end type sparsemat
+
+  interface sparsemat_matmul
+    module procedure sparsemat_matmul1
+    module procedure sparsemat_matmul2
+    module procedure sprasemat_matmul3
+    module procedure sprasemat_matmul4
+  end interface
+  public :: sparsemat_matmul
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public parameters & variables
+  !
+  integer, public, parameter :: SPARSEMAT_STORAGE_TYPEID_CSR = 1
+  integer, public, parameter :: SPARSEMAT_STORAGE_TYPEID_ELL = 2
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedure
+  !
+  private :: sparsemat_matmul_CSR_1
+  private :: sparsemat_matmul_CSR_2
+  private :: sparsemat_matmul_ELL_1
+  private :: sparsemat_matmul_ELL_2
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private parameters & variables
+  !
+  
+  !-----------------------------------------------------------------------------
+
+contains
+  subroutine sparsemat_Init( this, mat, &
+      EPS, storage_format )
+    implicit none
+
+    class(SparseMat), intent(inout) :: this
+    real(RP), intent(in) :: mat(:,:)
+    real(RP), optional, intent(in) :: EPS
+    character(len=*), optional, intent(in) :: storage_format
+
+    integer :: i
+    integer :: j
+    integer :: l
+
+    integer :: val_counter
+    integer :: rowptr_counter
+    
+    real(DP) :: tmp_val(size(mat)+1)
+    integer :: tmp_colInd(size(mat)+1)
+    integer :: tmp_rowptr(0:size(mat,1)+1)
+
+    real(RP) :: EPS_
+    character(len=H_MID) :: storage_format_ = 'CSR' 
+
+    integer :: row_nonzero_counter(size(mat,1))
+    integer :: col_size_l
+
+    !--------------------------------------------------------------------------- 
+ 
+    this%M = size(mat,1)
+    this%N = size(mat,2)
+
+    val_counter     = 1
+    rowptr_counter  = 1
+    tmp_rowptr(1)   = 1
+    tmp_val(:)      = 0.0_RP
+
+    if (present(EPS)) then
+      EPS_ = EPS
+    else
+      EPS_ = CONST_EPS * 500.0_RP ! ~ 1x10^-13
+    end if
+
+    if (present(storage_format)) then
+      storage_format_ = storage_format
+    end if
+
+    select case (storage_format_)
+    case ('CSR')
+      this%storage_format_id = SPARSEMAT_STORAGE_TYPEID_CSR
+
+      do i=1, this%M
+        do j=1, this%N
+          if ( abs(mat(i,j)) > EPS_ ) then
+            tmp_val(val_counter) = mat(i,j)
+            tmp_colInd(val_counter) = j
+            val_counter = val_counter + 1
+          end if
+        end do
+        rowptr_counter = rowptr_counter + 1
+        tmp_rowptr(rowptr_counter) = val_counter
+      end do
+    case ('ELL')
+      this%storage_format_id = SPARSEMAT_STORAGE_TYPEID_ELL
+
+      do i=1, this%M
+        row_nonzero_counter(i) = 0
+        do j=1, this%N
+          if ( abs(mat(i,j)) > EPS_ ) &
+            row_nonzero_counter(i) = row_nonzero_counter(i) + 1
+        end do
+      end do
+      this%col_size = maxval(row_nonzero_counter(:))
+      val_counter   = this%M * this%col_size
+
+      tmp_val(:)    = 0.0_RP
+      tmp_colInd(:) = -1
+      do i=1, this%M
+        col_size_l = 0
+        do j=1,this%N
+          if ( abs(mat(i,j)) > EPS_ ) then
+              col_size_l = col_size_l + 1
+              l = i+(col_size_l-1)*this%M
+              tmp_val   (l) = mat(i,j)   
+              tmp_colInd(l) = j
+          end if
+        end do
+      end do
+    case default
+      LOG_ERROR("SparseMat_Init",*) 'Not appropriate names of storage format. Check!', trim(storage_format_)
+      call PRC_abort
+    end select
+
+    this%nnz = val_counter
+    allocate( this%val(val_counter) )
+    allocate( this%colIdx(val_counter) )
+    this%val(:)    = tmp_val   (1:val_counter)
+    this%colIdx(:) = tmp_colInd(1:val_counter)
+
+    select case (storage_format_)
+    case ('CSR')
+      allocate( this%rowPtr(rowptr_counter) )
+      this%rowPtr(:) = tmp_rowptr(1:rowptr_counter)
+      this%rowPtrSize = rowptr_counter
+    case('ELL')
+      do l=2, val_counter
+        if (this%colIdx(l) == -1) then
+          this%colIdx(l) = this%colIdx(l-1)
+        end if
+      end do
+    end select
+
+    !write(*,*) "--- Mat ------"
+    !write(*,*) "shape:", shape(mat)
+    !write(*,*) "size:", size(mat)
+    ! do j=1, size(mat,2)
+    !    write(*,*) mat(:,j)
+    ! end do
+    !write(*,*) "--- Compressed Mat ------"
+    !write(*,*) "shape (Mat, colInd, rowPtr):", &
+    !  & shape(this%val), shape(this%colInd), shape(this%rowPtr)
+    ! write(*,*) "val:", this%val(:)
+    ! write(*,*) "colInd:", this%colInd(:)
+    ! write(*,*) "rowPtr:", this%rowPtr(:)
+
+    return
+  end subroutine sparsemat_Init
+
+  subroutine sparsemat_Final(this)
+    implicit none
+    class(SparseMat), intent(inout) :: this
+
+    !--------------------------------------------------------------------------- 
+
+    deallocate( this%val )
+    deallocate( this%colIdx )
+
+    select case( this%storage_format_id )
+    case( SPARSEMAT_STORAGE_TYPEID_CSR )
+      deallocate( this%rowPtr )
+    end select
+
+    return
+  end subroutine sparsemat_Final
+
+  function sparsemat_GetVal(A, i, j) result(v)
+    class(sparsemat), intent(in) :: A
+    integer, intent(in) :: i, j
+
+    real(DP) ::v
+    integer :: n
+    integer :: jj
+    !--------------------------------------------------------------------------- 
+
+    v = UNDEF8
+    select case( A%storage_format_id )
+    case( SPARSEMAT_STORAGE_TYPEID_CSR )
+      do n=A%rowPtr(i),A%rowPtr(i+1)-1
+        if (A%colIdx(n) == j) then
+          v = A%val(n); exit
+        end if
+      end do
+    case ( SPARSEMAT_STORAGE_TYPEID_ELL )
+      do jj=1, A%col_size
+        n = i + (jj-1)*A%M
+        if (A%colIdx(n) == j) then
+          v = A%val(n); exit
+        end if
+      end do
+    end select
+
+    return
+  end function sparsemat_GetVal
+
+  subroutine sparsemat_ReplceVal(A, i, j, v)
+    
+    class(sparsemat), intent(inout) :: A
+    integer, intent(in) :: i, j
+    real(RP), intent(in) ::v
+
+    integer :: n
+    integer :: jj
+    !--------------------------------------------------------------------------- 
+
+    select case ( A%storage_format_id )
+    case ( SPARSEMAT_STORAGE_TYPEID_CSR )
+      do n=A%rowPtr(i),A%rowPtr(i+1)-1
+        if (A%colIdx(n) == j) then
+          A%val(n) = v; exit
+        end if
+      end do
+    case ( SPARSEMAT_STORAGE_TYPEID_ELL )
+      do jj=1, A%col_size
+        n = i + (jj-1)*A%M
+        if (A%colIdx(n) == j) then
+          A%val(n) = v; exit
+        end if
+      end do
+    end select
+
+    return
+  end subroutine sparsemat_ReplceVal
+
+  subroutine sparsemat_print(A)
+    implicit none
+    class(sparsemat), intent(in) :: A
+
+    real(RP) :: row_val(A%N)
+    integer :: p
+    integer :: j1, j2
+    !--------------------------------------------------------------------------- 
+
+    write(*,*) "-- print matrix:"
+    write(*,'(a,i5,a,i5)') "orginal matrix shape:", A%M, 'x', A%N
+    write(*,'(a,i5)') "size of compressed matrix:", A%nnz
+    select case ( A%storage_format_id )
+    case ( SPARSEMAT_STORAGE_TYPEID_CSR )
+      write(*,*) "rowPtr:", A%rowPtr(:)
+    end select
+    write(*,*) "colInd:", A%colIdx(:)
+    write(*,*) "val:"
+
+    select case ( A%storage_format_id )
+    case ( SPARSEMAT_STORAGE_TYPEID_CSR )
+      j1 = A%rowPtr(1)
+      do p=1, A%rowPtrSize-1
+        j2 = A%rowPtr(p+1)
+        row_val(:) = 0.0_RP
+        row_val(A%colIdx(j1:j2-1)) = A%val(j1:j2-1)
+        write(*,*) row_val(:)
+        j1 = j2
+      end do
+    case ( SPARSEMAT_STORAGE_TYPEID_ELL )
+      do p=1, A%M
+        row_val(:) = 0.0_RP
+        do j1=1, A%col_size
+          j2 = p + (j1-1)*A%M
+         row_val(A%colIdx(j2)) = A%val(j2)
+        end do
+        write(*,*) row_val(:)
+      end do
+    end select
+
+    return
+  end subroutine sparsemat_print
+
+  function sparsemat_get_storage_format_id( A ) result(id)
+    implicit none
+    class(sparsemat), intent(in) :: A
+    real(RP) :: id
+    !------------------------------------------------------
+
+    id = A%storage_format_id
+    return 
+  end function sparsemat_get_storage_format_id
+
+!OCL SERIAL  
+  subroutine sparsemat_matmul1(A, b, c)
+    implicit none
+
+    type(sparsemat), intent(in) :: A
+    real(RP), intent(in ) :: b(:)
+    real(RP), intent(out) :: c(A%M)
+
+    !--------------------------------------------------------------------------- 
+
+    select case( A%storage_format_id )
+    case( SPARSEMAT_STORAGE_TYPEID_CSR )
+      call sparsemat_matmul_CSR_1( A%val, A%colIdx, A%rowPtr, b, c, &
+        A%M, A%N, A%nnz, A%rowPtrSize                          )
+    case( SPARSEMAT_STORAGE_TYPEID_ELL )
+      call sparsemat_matmul_ELL_1( A%val, A%colIdx, b, c,           &
+        A%M, A%N, A%nnz, A%col_size                            )
+    end select
+
+    return
+  end subroutine sparsemat_matmul1
+
+!OCL SERIAL  
+  subroutine sparsemat_matmul2(A, b, c)
+    implicit none
+
+    type(sparsemat), intent(in) :: A
+    real(RP), intent(in ) :: b(:,:)
+    real(RP), intent(out) :: c(size(b, 1),A%M)
+
+    !--------------------------------------------------------------------------- 
+    select case( A%storage_format_id )
+    case( SPARSEMAT_STORAGE_TYPEID_CSR )
+      call sparsemat_matmul_CSR_2( A%val, A%colIdx, A%rowPtr, b, c, &
+        A%M, A%N, A%nnz, A%rowPtrSize, size(b,1)               )
+    case( SPARSEMAT_STORAGE_TYPEID_ELL )
+      call sparsemat_matmul_ELL_2( A%val, A%colIdx, b, c,           &
+        A%M, A%N, A%nnz, A%col_size, size(b,1)                 )
+    end select
+
+    return
+  end subroutine sparsemat_matmul2
+
+!OCL SERIAL
+  subroutine sprasemat_matmul3(A, b, c, Nvec)
+    implicit none
+
+    type(sparsemat), intent(in) :: A
+    integer, intent(in) :: Nvec
+    real(RP), intent(in) :: b(:,:)
+    real(RP), intent(out) :: c(size(b, 1), Nvec)
+
+    integer :: kvec
+    integer :: M
+    integer :: col_size
+    ! integer :: col_Ind(A%nnz)
+    ! real(RP) :: A_(A%nnz)
+
+    integer :: k, kk, i
+    integer :: j_ptr
+    
+    !---Note: Only for ELL format
+    M = A%M
+    col_size = A%col_size
+    
+    c(:,:) = 0.0_RP
+    ! do k=1, A%nnz
+    !   A_(k) = A%val(k)
+    ! enddo
+    ! do k=1, A%nnz
+    !   col_Ind(k) = A%colIdx(k)
+    ! enddo
+
+    do k=1, col_size
+      kk = M * (k-1)
+      do i=1, M
+        j_ptr = kk + i        
+        c(i, 1) = c(i, 1) + A%val(j_ptr) * b(A%colIdx(j_ptr), 1)
+        c(i, 2) = c(i, 2) + A%val(j_ptr) * b(A%colIdx(j_ptr), 2)
+        c(i, 3) = c(i, 3) + A%val(j_ptr) * b(A%colIdx(j_ptr), 3)
+        c(i, 4) = c(i, 4) + A%val(j_ptr) * b(A%colIdx(j_ptr), 4)
+        c(i, 5) = c(i, 5) + A%val(j_ptr) * b(A%colIdx(j_ptr), 5)
+        c(i, 6) = c(i, 6) + A%val(j_ptr) * b(A%colIdx(j_ptr), 6)
+      end do
+    end do
+
+    return
+  end subroutine
+
+!OCL SERIAL
+  subroutine sprasemat_matmul4(A, b, c, Nvec, DUMMY)
+    implicit none
+
+    type(sparsemat), intent(in) :: A
+    integer, intent(in) :: Nvec, DUMMY
+    real(RP), intent(in) :: b(:,:)
+    real(RP), intent(out) :: c(size(b, 1), Nvec)
+
+    integer :: kvec
+    integer :: M
+    integer :: col_size
+    ! integer :: col_Ind(A%nnz)
+    ! real(RP) :: A_(A%nnz)
+
+    integer :: k, kk, i
+    integer :: j_ptr
+    
+    !---Note: Only for ELL format
+    M = A%M
+    col_size = A%col_size
+    
+    c(:,:) = 0.0_RP
+
+    do k=1, col_size
+      kk = M * (k-1)
+      do i=1, M
+        j_ptr = kk + i        
+        c(i, 1) = c(i, 1) + A%val(j_ptr) * b(A%colIdx(j_ptr), 1)
+        c(i, 2) = c(i, 2) + A%val(j_ptr) * b(A%colIdx(j_ptr), 2)
+        c(i, 3) = c(i, 3) + A%val(j_ptr) * b(A%colIdx(j_ptr), 3)
+        c(i, 4) = c(i, 4) + A%val(j_ptr) * b(A%colIdx(j_ptr), 4)
+        c(i, 5) = c(i, 5) + A%val(j_ptr) * b(A%colIdx(j_ptr), 5)
+        c(i, 6) = c(i, 6) + A%val(j_ptr) * b(A%colIdx(j_ptr), 6)
+        c(i, 7) = c(i, 7) + A%val(j_ptr) * b(A%colIdx(j_ptr), 7)
+      end do
+    end do
+
+    return
+  end subroutine
+!--- private ----------------------------------------------
+
+!OCL SERIAL
+  subroutine sparsemat_matmul_CSR_1(A, col_Ind, rowPtr, b, c, M, N, buf_size, rowPtr_size)
+    implicit none
+
+    integer, intent(in) :: M
+    integer, intent(in) :: N
+    integer, intent(in) :: buf_size
+    integer, intent(in) :: rowPtr_size
+    real(RP), intent(in) :: A(buf_size)
+    integer, intent(in) :: col_Ind(buf_size)
+    integer, intent(in) :: rowPtr(rowPtr_size)
+    real(RP), intent(in ) :: b(N)
+    real(RP), intent(out) :: c(M)
+
+    integer :: p, j
+    integer :: j1, j2
+
+    !--------------------------------------------------------------------------- 
+
+    !call mkl_dcsrgemv( 'N', rowPtr_size-1, A, rowPtr, col_Ind, b, c)
+    j1 = rowPtr(1)
+    do p=1, rowPtr_size-1
+       j2 = rowPtr(p+1) 
+       c(p) = 0.0_RP
+       do j=j1, j2-1
+          c(p) = c(p) + A(j) * b(col_Ind(j))
+       end do
+       j1 = j2
+    end do
+
+    return
+  end subroutine sparsemat_matmul_CSR_1
+
+!OCL SERIAL
+  subroutine sparsemat_matmul_CSR_2(A, col_Ind, rowPtr, b, c, M, N, buf_size, rowPtr_size, NQ)
+    implicit none
+
+    integer, intent(in) :: M
+    integer, intent(in) :: N
+    integer, intent(in) :: NQ
+    integer, intent(in) :: buf_size
+    integer, intent(in) :: rowPtr_size
+    real(RP), intent(in) :: A(buf_size)
+    integer, intent(in) :: col_Ind(buf_size)
+    integer, intent(in) :: rowPtr(rowPtr_size)
+    real(RP), intent(in ) :: b(NQ,N)
+    real(RP), intent(out) :: c(NQ,M)
+
+    integer :: p, j
+    integer :: j1, j2
+
+    !--------------------------------------------------------------------------- 
+
+    !call mkl_dcsrgemv( 'N', rowPtr_size-1, A, rowPtr, col_Ind, b, c)
+    j1 = rowPtr(1)
+    c(:,:) = 0.0_RP
+    do p=1, rowPtr_size-1
+      j2 = rowPtr(p+1) 
+      do j=j1, j2-1
+        c(:,p) = c(:,p) + A(j) * b(:,col_Ind(j))
+      end do
+      j1 = j2
+    end do
+
+    return
+  end subroutine sparsemat_matmul_CSR_2
+
+!OCL SERIAL
+  subroutine sparsemat_matmul_ELL_1(A, col_Ind, b, c, M, N, buf_size, col_size)
+    implicit none
+
+    integer, intent(in) :: M
+    integer, intent(in) :: N
+    integer, intent(in) :: buf_size
+    integer, intent(in) :: col_size
+    real(RP), intent(in) :: A(buf_size)
+    integer, intent(in) :: col_Ind(buf_size)
+    real(RP), intent(in ) :: b(N)
+    real(RP), intent(out) :: c(M)
+
+    integer :: k, kk, i
+    integer :: j_ptr
+    !--------------------------------------------------------------------------- 
+
+    c(:) = 0.0_RP
+    do k=1, col_size
+      kk = M * (k-1)
+      do i=1, M
+        j_ptr = kk + i        
+        c(i) = c(i) + A(j_ptr) * b(col_Ind(j_ptr))
+      end do
+    end do
+
+    return
+  end subroutine sparsemat_matmul_ELL_1
+
+!OCL SERIAL
+  subroutine sparsemat_matmul_ELL_2(A, col_Ind, b, c, M, N, buf_size, col_size, NQ)
+    implicit none
+
+    integer, intent(in) :: M
+    integer, intent(in) :: N
+    integer, intent(in) :: buf_size
+    integer, intent(in) :: col_size
+    integer, intent(in) :: NQ
+    real(RP), intent(in) :: A(buf_size)
+    integer, intent(in) :: col_Ind(buf_size)
+    real(RP), intent(in ) :: b(NQ,N)
+    real(RP), intent(out) :: c(NQ,M)
+
+    integer :: k, kk, i
+    integer :: j_ptr
+    !--------------------------------------------------------------------------- 
+
+    c(:,:) = 0.0_RP
+    do k=1, col_size
+      kk = M * (k-1)
+      do i=1, M
+        j_ptr = kk + i        
+        c(:,i) = c(:,i) + A(j_ptr) * b(:,col_Ind(j_ptr))
+      end do
+    end do
+
+    return
+  end subroutine sparsemat_matmul_ELL_2
+
+end module scale_sparsemat
+

--- a/FElib/src/common/scale_sparsemat_tune2.F90
+++ b/FElib/src/common/scale_sparsemat_tune2.F90
@@ -1,0 +1,586 @@
+#include "scaleFElib.h"
+module scale_sparsemat
+  !-----------------------------------------------------------------------------
+  !
+  !++ used modules
+  !
+  use scale_precision
+  use scale_io
+  use scale_prc
+  use scale_const, only:    &
+    UNDEF8 => CONST_UNDEF8, &
+    CONST_EPS
+  
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public type & procedure
+  !  
+
+  type, public :: sparsemat
+    integer :: M                      !< Number of row of original matrix
+    integer :: N                      !< Number of column of original matrix
+    integer :: nnz                    !< Number of nonzero of the matrix
+    real(RP), allocatable :: val(:)   !< Array storing the values of the nonzeros
+    integer, allocatable :: colIdx(:) !< Array saving the column indices of the nonzeros
+
+    ! for CSR format
+    integer, allocatable :: rowPtr(:) !< Array saving the start and end pointers of the nonzeros of the rows.
+    integer :: rowPtrSize             !< Size of rowPtr
+
+    ! for ELL format
+    integer :: col_size
+
+    integer, private :: storage_format_id      !< Number of row of original matrix
+  contains
+    procedure, public :: Init => sparsemat_Init
+    procedure, public :: Final => sparsemat_Final
+    procedure, public :: Print => sparsemat_Print
+    procedure, public :: ReplaceVal => sparsemat_ReplceVal
+    procedure, public :: GetVal => sparsemat_GetVal
+    procedure, public :: GetStorageFormatId => sparsemat_get_storage_format_id
+  end type sparsemat
+
+  interface sparsemat_matmul
+    module procedure sparsemat_matmul1
+    module procedure sparsemat_matmul2
+    module procedure sprasemat_matmul3
+    module procedure sprasemat_matmul4
+  end interface
+  public :: sparsemat_matmul
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public parameters & variables
+  !
+  integer, public, parameter :: SPARSEMAT_STORAGE_TYPEID_CSR = 1
+  integer, public, parameter :: SPARSEMAT_STORAGE_TYPEID_ELL = 2
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedure
+  !
+  private :: sparsemat_matmul_CSR_1
+  private :: sparsemat_matmul_CSR_2
+  private :: sparsemat_matmul_ELL_1
+  private :: sparsemat_matmul_ELL_2
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private parameters & variables
+  !
+  
+  !-----------------------------------------------------------------------------
+
+contains
+  subroutine sparsemat_Init( this, mat, &
+      EPS, storage_format )
+    implicit none
+
+    class(SparseMat), intent(inout) :: this
+    real(RP), intent(in) :: mat(:,:)
+    real(RP), optional, intent(in) :: EPS
+    character(len=*), optional, intent(in) :: storage_format
+
+    integer :: i
+    integer :: j
+    integer :: l
+
+    integer :: val_counter
+    integer :: rowptr_counter
+    
+    real(DP) :: tmp_val(size(mat)+1)
+    integer :: tmp_colInd(size(mat)+1)
+    integer :: tmp_rowptr(0:size(mat,1)+1)
+
+    real(RP) :: EPS_
+    character(len=H_MID) :: storage_format_ = 'CSR' 
+
+    integer :: row_nonzero_counter(size(mat,1))
+    integer :: col_size_l
+
+    !--------------------------------------------------------------------------- 
+ 
+    this%M = size(mat,1)
+    this%N = size(mat,2)
+
+    val_counter     = 1
+    rowptr_counter  = 1
+    tmp_rowptr(1)   = 1
+    tmp_val(:)      = 0.0_RP
+
+    if (present(EPS)) then
+      EPS_ = EPS
+    else
+      EPS_ = CONST_EPS * 500.0_RP ! ~ 1x10^-13
+    end if
+
+    if (present(storage_format)) then
+      storage_format_ = storage_format
+    end if
+
+    select case (storage_format_)
+    case ('CSR')
+      this%storage_format_id = SPARSEMAT_STORAGE_TYPEID_CSR
+
+      do i=1, this%M
+        do j=1, this%N
+          if ( abs(mat(i,j)) > EPS_ ) then
+            tmp_val(val_counter) = mat(i,j)
+            tmp_colInd(val_counter) = j
+            val_counter = val_counter + 1
+          end if
+        end do
+        rowptr_counter = rowptr_counter + 1
+        tmp_rowptr(rowptr_counter) = val_counter
+      end do
+    case ('ELL')
+      this%storage_format_id = SPARSEMAT_STORAGE_TYPEID_ELL
+
+      do i=1, this%M
+        row_nonzero_counter(i) = 0
+        do j=1, this%N
+          if ( abs(mat(i,j)) > EPS_ ) &
+            row_nonzero_counter(i) = row_nonzero_counter(i) + 1
+        end do
+      end do
+      this%col_size = maxval(row_nonzero_counter(:))
+      val_counter   = this%M * this%col_size
+
+      tmp_val(:)    = 0.0_RP
+      tmp_colInd(:) = -1
+      do i=1, this%M
+        col_size_l = 0
+        do j=1,this%N
+          if ( abs(mat(i,j)) > EPS_ ) then
+              col_size_l = col_size_l + 1
+              l = i+(col_size_l-1)*this%M
+              tmp_val   (l) = mat(i,j)   
+              tmp_colInd(l) = j
+          end if
+        end do
+      end do
+    case default
+      LOG_ERROR("SparseMat_Init",*) 'Not appropriate names of storage format. Check!', trim(storage_format_)
+      call PRC_abort
+    end select
+
+    this%nnz = val_counter
+    allocate( this%val(val_counter) )
+    allocate( this%colIdx(val_counter) )
+    this%val(:)    = tmp_val   (1:val_counter)
+    this%colIdx(:) = tmp_colInd(1:val_counter)
+
+    select case (storage_format_)
+    case ('CSR')
+      allocate( this%rowPtr(rowptr_counter) )
+      this%rowPtr(:) = tmp_rowptr(1:rowptr_counter)
+      this%rowPtrSize = rowptr_counter
+    case('ELL')
+      do l=2, val_counter
+        if (this%colIdx(l) == -1) then
+          this%colIdx(l) = this%colIdx(l-1)
+        end if
+      end do
+    end select
+
+    !write(*,*) "--- Mat ------"
+    !write(*,*) "shape:", shape(mat)
+    !write(*,*) "size:", size(mat)
+    ! do j=1, size(mat,2)
+    !    write(*,*) mat(:,j)
+    ! end do
+    !write(*,*) "--- Compressed Mat ------"
+    !write(*,*) "shape (Mat, colInd, rowPtr):", &
+    !  & shape(this%val), shape(this%colInd), shape(this%rowPtr)
+    ! write(*,*) "val:", this%val(:)
+    ! write(*,*) "colInd:", this%colInd(:)
+    ! write(*,*) "rowPtr:", this%rowPtr(:)
+
+    return
+  end subroutine sparsemat_Init
+
+  subroutine sparsemat_Final(this)
+    implicit none
+    class(SparseMat), intent(inout) :: this
+
+    !--------------------------------------------------------------------------- 
+
+    deallocate( this%val )
+    deallocate( this%colIdx )
+
+    select case( this%storage_format_id )
+    case( SPARSEMAT_STORAGE_TYPEID_CSR )
+      deallocate( this%rowPtr )
+    end select
+
+    return
+  end subroutine sparsemat_Final
+
+  function sparsemat_GetVal(A, i, j) result(v)
+    class(sparsemat), intent(in) :: A
+    integer, intent(in) :: i, j
+
+    real(DP) ::v
+    integer :: n
+    integer :: jj
+    !--------------------------------------------------------------------------- 
+
+    v = UNDEF8
+    select case( A%storage_format_id )
+    case( SPARSEMAT_STORAGE_TYPEID_CSR )
+      do n=A%rowPtr(i),A%rowPtr(i+1)-1
+        if (A%colIdx(n) == j) then
+          v = A%val(n); exit
+        end if
+      end do
+    case ( SPARSEMAT_STORAGE_TYPEID_ELL )
+      do jj=1, A%col_size
+        n = i + (jj-1)*A%M
+        if (A%colIdx(n) == j) then
+          v = A%val(n); exit
+        end if
+      end do
+    end select
+
+    return
+  end function sparsemat_GetVal
+
+  subroutine sparsemat_ReplceVal(A, i, j, v)
+    
+    class(sparsemat), intent(inout) :: A
+    integer, intent(in) :: i, j
+    real(RP), intent(in) ::v
+
+    integer :: n
+    integer :: jj
+    !--------------------------------------------------------------------------- 
+
+    select case ( A%storage_format_id )
+    case ( SPARSEMAT_STORAGE_TYPEID_CSR )
+      do n=A%rowPtr(i),A%rowPtr(i+1)-1
+        if (A%colIdx(n) == j) then
+          A%val(n) = v; exit
+        end if
+      end do
+    case ( SPARSEMAT_STORAGE_TYPEID_ELL )
+      do jj=1, A%col_size
+        n = i + (jj-1)*A%M
+        if (A%colIdx(n) == j) then
+          A%val(n) = v; exit
+        end if
+      end do
+    end select
+
+    return
+  end subroutine sparsemat_ReplceVal
+
+  subroutine sparsemat_print(A)
+    implicit none
+    class(sparsemat), intent(in) :: A
+
+    real(RP) :: row_val(A%N)
+    integer :: p
+    integer :: j1, j2
+    !--------------------------------------------------------------------------- 
+
+    write(*,*) "-- print matrix:"
+    write(*,'(a,i5,a,i5)') "orginal matrix shape:", A%M, 'x', A%N
+    write(*,'(a,i5)') "size of compressed matrix:", A%nnz
+    select case ( A%storage_format_id )
+    case ( SPARSEMAT_STORAGE_TYPEID_CSR )
+      write(*,*) "rowPtr:", A%rowPtr(:)
+    end select
+    write(*,*) "colInd:", A%colIdx(:)
+    write(*,*) "val:"
+
+    select case ( A%storage_format_id )
+    case ( SPARSEMAT_STORAGE_TYPEID_CSR )
+      j1 = A%rowPtr(1)
+      do p=1, A%rowPtrSize-1
+        j2 = A%rowPtr(p+1)
+        row_val(:) = 0.0_RP
+        row_val(A%colIdx(j1:j2-1)) = A%val(j1:j2-1)
+        write(*,*) row_val(:)
+        j1 = j2
+      end do
+    case ( SPARSEMAT_STORAGE_TYPEID_ELL )
+      do p=1, A%M
+        row_val(:) = 0.0_RP
+        do j1=1, A%col_size
+          j2 = p + (j1-1)*A%M
+         row_val(A%colIdx(j2)) = A%val(j2)
+        end do
+        write(*,*) row_val(:)
+      end do
+    end select
+
+    return
+  end subroutine sparsemat_print
+
+  function sparsemat_get_storage_format_id( A ) result(id)
+    implicit none
+    class(sparsemat), intent(in) :: A
+    real(RP) :: id
+    !------------------------------------------------------
+
+    id = A%storage_format_id
+    return 
+  end function sparsemat_get_storage_format_id
+
+!OCL SERIAL  
+  subroutine sparsemat_matmul1(A, b, c)
+    implicit none
+
+    type(sparsemat), intent(in) :: A
+    real(RP), intent(in ) :: b(:)
+    real(RP), intent(out) :: c(A%M)
+
+    !--------------------------------------------------------------------------- 
+
+    select case( A%storage_format_id )
+    case( SPARSEMAT_STORAGE_TYPEID_CSR )
+      call sparsemat_matmul_CSR_1( A%val, A%colIdx, A%rowPtr, b, c, &
+        A%M, A%N, A%nnz, A%rowPtrSize                          )
+    case( SPARSEMAT_STORAGE_TYPEID_ELL )
+      call sparsemat_matmul_ELL_1( A%val, A%colIdx, b, c,           &
+        A%M, A%N, A%nnz, A%col_size                            )
+    end select
+
+    return
+  end subroutine sparsemat_matmul1
+
+!OCL SERIAL  
+  subroutine sparsemat_matmul2(A, b, c)
+    implicit none
+
+    type(sparsemat), intent(in) :: A
+    real(RP), intent(in ) :: b(:,:)
+    real(RP), intent(out) :: c(size(b, 1),A%M)
+
+    !--------------------------------------------------------------------------- 
+    select case( A%storage_format_id )
+    case( SPARSEMAT_STORAGE_TYPEID_CSR )
+      call sparsemat_matmul_CSR_2( A%val, A%colIdx, A%rowPtr, b, c, &
+        A%M, A%N, A%nnz, A%rowPtrSize, size(b,1)               )
+    case( SPARSEMAT_STORAGE_TYPEID_ELL )
+      call sparsemat_matmul_ELL_2( A%val, A%colIdx, b, c,           &
+        A%M, A%N, A%nnz, A%col_size, size(b,1)                 )
+    end select
+
+    return
+  end subroutine sparsemat_matmul2
+
+!OCL SERIAL
+  subroutine sprasemat_matmul3(A, b, c, Nvec)
+    implicit none
+
+    type(sparsemat), intent(in) :: A
+    integer, intent(in) :: Nvec
+    real(RP), intent(in) :: b(:,:)
+    real(RP), intent(out) :: c(size(b, 2), Nvec)
+
+    integer :: kvec
+    integer :: M
+    integer :: col_size
+    ! integer :: col_Ind(A%nnz)
+    ! real(RP) :: A_(A%nnz)
+
+    integer :: k, kk, i
+    integer :: j_ptr
+    
+    !---Note: Only for ELL format
+    M = A%M
+    col_size = A%col_size
+    
+    c(:,:) = 0.0_RP
+
+    do k=1, col_size
+      kk = M * (k-1)
+      do i=1, M
+        j_ptr = kk + i        
+        c(i, 1) = c(i, 1) + A%val(j_ptr) * b(1, A%colIdx(j_ptr))
+        c(i, 2) = c(i, 2) + A%val(j_ptr) * b(2, A%colIdx(j_ptr))
+        c(i, 3) = c(i, 3) + A%val(j_ptr) * b(3, A%colIdx(j_ptr))
+        c(i, 4) = c(i, 4) + A%val(j_ptr) * b(4, A%colIdx(j_ptr))
+        c(i, 5) = c(i, 5) + A%val(j_ptr) * b(5, A%colIdx(j_ptr))
+        c(i, 6) = c(i, 6) + A%val(j_ptr) * b(6, A%colIdx(j_ptr))
+      end do
+    end do
+
+    return
+  end subroutine
+
+!OCL SERIAL
+  subroutine sprasemat_matmul4(A, b, c, Nvec, DUMMY)
+    implicit none
+
+    type(sparsemat), intent(in) :: A
+    integer, intent(in) :: Nvec, DUMMY
+    real(RP), intent(in) :: b(:,:)
+    real(RP), intent(out) :: c(size(b, 2), Nvec)
+
+    integer :: kvec
+    integer :: M
+    integer :: col_size
+    ! integer :: col_Ind(A%nnz)
+    ! real(RP) :: A_(A%nnz)
+
+    integer :: k, kk, i
+    integer :: j_ptr
+    
+    !---Note: Only for ELL format
+    M = A%M
+    col_size = A%col_size
+    
+    c(:,:) = 0.0_RP
+
+    do k=1, col_size
+      kk = M * (k-1)
+      do i=1, M
+        j_ptr = kk + i        
+        c(i, 1) = c(i, 1) + A%val(j_ptr) * b(1, A%colIdx(j_ptr))
+        c(i, 2) = c(i, 2) + A%val(j_ptr) * b(2, A%colIdx(j_ptr))
+        c(i, 3) = c(i, 3) + A%val(j_ptr) * b(3, A%colIdx(j_ptr))
+        c(i, 4) = c(i, 4) + A%val(j_ptr) * b(4, A%colIdx(j_ptr))
+        c(i, 5) = c(i, 5) + A%val(j_ptr) * b(5, A%colIdx(j_ptr))
+        c(i, 6) = c(i, 6) + A%val(j_ptr) * b(6, A%colIdx(j_ptr))
+        c(i, 7) = c(i, 7) + A%val(j_ptr) * b(7, A%colIdx(j_ptr))
+      end do
+    end do
+
+    return
+  end subroutine
+!--- private ----------------------------------------------
+
+!OCL SERIAL
+  subroutine sparsemat_matmul_CSR_1(A, col_Ind, rowPtr, b, c, M, N, buf_size, rowPtr_size)
+    implicit none
+
+    integer, intent(in) :: M
+    integer, intent(in) :: N
+    integer, intent(in) :: buf_size
+    integer, intent(in) :: rowPtr_size
+    real(RP), intent(in) :: A(buf_size)
+    integer, intent(in) :: col_Ind(buf_size)
+    integer, intent(in) :: rowPtr(rowPtr_size)
+    real(RP), intent(in ) :: b(N)
+    real(RP), intent(out) :: c(M)
+
+    integer :: p, j
+    integer :: j1, j2
+
+    !--------------------------------------------------------------------------- 
+
+    !call mkl_dcsrgemv( 'N', rowPtr_size-1, A, rowPtr, col_Ind, b, c)
+    j1 = rowPtr(1)
+    do p=1, rowPtr_size-1
+       j2 = rowPtr(p+1) 
+       c(p) = 0.0_RP
+       do j=j1, j2-1
+          c(p) = c(p) + A(j) * b(col_Ind(j))
+       end do
+       j1 = j2
+    end do
+
+    return
+  end subroutine sparsemat_matmul_CSR_1
+
+!OCL SERIAL
+  subroutine sparsemat_matmul_CSR_2(A, col_Ind, rowPtr, b, c, M, N, buf_size, rowPtr_size, NQ)
+    implicit none
+
+    integer, intent(in) :: M
+    integer, intent(in) :: N
+    integer, intent(in) :: NQ
+    integer, intent(in) :: buf_size
+    integer, intent(in) :: rowPtr_size
+    real(RP), intent(in) :: A(buf_size)
+    integer, intent(in) :: col_Ind(buf_size)
+    integer, intent(in) :: rowPtr(rowPtr_size)
+    real(RP), intent(in ) :: b(NQ,N)
+    real(RP), intent(out) :: c(NQ,M)
+
+    integer :: p, j
+    integer :: j1, j2
+
+    !--------------------------------------------------------------------------- 
+
+    !call mkl_dcsrgemv( 'N', rowPtr_size-1, A, rowPtr, col_Ind, b, c)
+    j1 = rowPtr(1)
+    c(:,:) = 0.0_RP
+    do p=1, rowPtr_size-1
+      j2 = rowPtr(p+1) 
+      do j=j1, j2-1
+        c(:,p) = c(:,p) + A(j) * b(:,col_Ind(j))
+      end do
+      j1 = j2
+    end do
+
+    return
+  end subroutine sparsemat_matmul_CSR_2
+
+!OCL SERIAL
+  subroutine sparsemat_matmul_ELL_1(A, col_Ind, b, c, M, N, buf_size, col_size)
+    implicit none
+
+    integer, intent(in) :: M
+    integer, intent(in) :: N
+    integer, intent(in) :: buf_size
+    integer, intent(in) :: col_size
+    real(RP), intent(in) :: A(buf_size)
+    integer, intent(in) :: col_Ind(buf_size)
+    real(RP), intent(in ) :: b(N)
+    real(RP), intent(out) :: c(M)
+
+    integer :: k, kk, i
+    integer :: j_ptr
+    !--------------------------------------------------------------------------- 
+
+    c(:) = 0.0_RP
+    do k=1, col_size
+      kk = M * (k-1)
+      do i=1, M
+        j_ptr = kk + i        
+        c(i) = c(i) + A(j_ptr) * b(col_Ind(j_ptr))
+      end do
+    end do
+
+    return
+  end subroutine sparsemat_matmul_ELL_1
+
+!OCL SERIAL
+  subroutine sparsemat_matmul_ELL_2(A, col_Ind, b, c, M, N, buf_size, col_size, NQ)
+    implicit none
+
+    integer, intent(in) :: M
+    integer, intent(in) :: N
+    integer, intent(in) :: buf_size
+    integer, intent(in) :: col_size
+    integer, intent(in) :: NQ
+    real(RP), intent(in) :: A(buf_size)
+    integer, intent(in) :: col_Ind(buf_size)
+    real(RP), intent(in ) :: b(NQ,N)
+    real(RP), intent(out) :: c(NQ,M)
+
+    integer :: k, kk, i
+    integer :: j_ptr
+    !--------------------------------------------------------------------------- 
+
+    c(:,:) = 0.0_RP
+    do k=1, col_size
+      kk = M * (k-1)
+      do i=1, M
+        j_ptr = kk + i        
+        c(:,i) = c(:,i) + A(j_ptr) * b(:,col_Ind(j_ptr))
+      end do
+    end do
+
+    return
+  end subroutine sparsemat_matmul_ELL_2
+
+end module scale_sparsemat
+

--- a/FElib/src/element/scale_element_modalfilter.F90
+++ b/FElib/src/element/scale_element_modalfilter.F90
@@ -39,7 +39,6 @@ module scale_element_modalfilter
   !
   type, public :: ModalFilter
     real(RP), allocatable :: FilterMat(:,:)
-    real(RP), allocatable :: FilterMatX(:,:)
   contains
     procedure :: Init_line => ModalFilter_Init_line
     procedure :: Init_quadrilateral => ModalFilter_Init_quadrilateral
@@ -169,9 +168,7 @@ contains
       tend_flag_ )                                               ! (in)
 
     allocate( this%FilterMat(elem%Np,elem%Np) )
-    allocate( this%FilterMatX(8,8) )
     this%FilterMat(:,:) = 0.0_RP
-    this%FilterMatX(:,:) = 0.0_RP
     do p3=1, elem%Nnode_v
     do p2=1, elem%Nnode_h1D
     do p1=1, elem%Nnode_h1D
@@ -193,7 +190,6 @@ contains
     !--------------------------------------------
 
     if( allocated(this%FilterMat) ) deallocate( this%FilterMat )
-    if( allocated(this%FilterMatX) ) deallocate( this%FilterMatX )
     
     return
   end subroutine ModalFilter_Final

--- a/FElib/src/element/scale_element_modalfilter.F90
+++ b/FElib/src/element/scale_element_modalfilter.F90
@@ -151,6 +151,10 @@ contains
 
     real(RP) :: filter1D_h(elem%Nnode_h1D)
     real(RP) :: filter1D_v(elem%Nnode_v)
+    !--- for 3 direction
+    !--- should create 1D_h and 1D_v, just for simplicity
+    type(LineElement) :: elem1D
+    !--- end
     integer :: p1, p2, p3
     integer :: l
     logical :: tend_flag_
@@ -167,19 +171,39 @@ contains
       etac_v, alpha_v, ord_V, elem%Nnode_v, elem%PolyOrder_v,  & ! (in)
       tend_flag_ )                                               ! (in)
 
-    allocate( this%FilterMat(elem%Np,elem%Np) )
+    ! -- original method
+    !allocate( this%FilterMat(elem%Np,elem%Np) )
+    !this%FilterMat(:,:) = 0.0_RP
+
+    !do p3=1, elem%Nnode_v
+    !do p2=1, elem%Nnode_h1D
+    !do p1=1, elem%Nnode_h1D
+    !  l = p1 + (p2-1)*elem%Nnode_h1D + (p3-1)*elem%Nnode_h1D**2
+    !  this%FilterMat(l,l) = filter1D_h(p1) * filter1D_h(p2) * filter1D_v(p3)
+    !end do  
+    !end do
+    !end do
+    !this%FilterMat(:,:) = matmul(this%FilterMat, elem%invV)
+    !this%FilterMat(:,:) = matmul(elem%V, this%FilterMat)
+
+    !--- init a line element
+    call elem1D%Init(elem%PolyOrder_h, .false.)
+
+    allocate( this%FilterMat(elem1D%Np,elem1D%Np) )
     this%FilterMat(:,:) = 0.0_RP
-    do p3=1, elem%Nnode_v
-    do p2=1, elem%Nnode_h1D
-    do p1=1, elem%Nnode_h1D
-      l = p1 + (p2-1)*elem%Nnode_h1D + (p3-1)*elem%Nnode_h1D**2
-      this%FilterMat(l,l) = filter1D_h(p1) * filter1D_h(p2) * filter1D_v(p3)
-    end do  
+
+    !--- assgin 1d filter to the matrix
+    do p1=1, elem1D%Np
+      this%FilterMat(p1,p1) = filter1D_h(p1)
     end do
-    end do
-    this%FilterMat(:,:) = matmul(this%FilterMat, elem%invV)
-    this%FilterMat(:,:) = matmul(elem%V, this%FilterMat)
-    
+
+    this%FilterMat(:,:) = matmul(this%FilterMat, elem1D%invV)
+    this%FilterMat(:,:) = matmul(elem1D%V, this%FilterMat)
+
+    !-- clean up
+
+    call elem1D%Final()
+
     return
   end subroutine ModalFilter_Init_hexahedral
 

--- a/FElib/src/element/scale_element_modalfilter.F90
+++ b/FElib/src/element/scale_element_modalfilter.F90
@@ -39,7 +39,7 @@ module scale_element_modalfilter
   !
   type, public :: ModalFilter
     real(RP), allocatable :: FilterMat(:,:)
-    real(RP), allocatable :: newMat(:,:)
+    real(RP), allocatable :: FilterMatX(:,:)
   contains
     procedure :: Init_line => ModalFilter_Init_line
     procedure :: Init_quadrilateral => ModalFilter_Init_quadrilateral
@@ -169,8 +169,9 @@ contains
       tend_flag_ )                                               ! (in)
 
     allocate( this%FilterMat(elem%Np,elem%Np) )
-    allocate( this%newMat(8,8) )
+    allocate( this%FilterMatX(8,8) )
     this%FilterMat(:,:) = 0.0_RP
+    this%FilterMatX(:,:) = 0.0_RP
     do p3=1, elem%Nnode_v
     do p2=1, elem%Nnode_h1D
     do p1=1, elem%Nnode_h1D
@@ -192,7 +193,7 @@ contains
     !--------------------------------------------
 
     if( allocated(this%FilterMat) ) deallocate( this%FilterMat )
-    if( allocated(this%newMat) ) deallocate( this%newMat )
+    if( allocated(this%FilterMatX) ) deallocate( this%FilterMatX )
     
     return
   end subroutine ModalFilter_Final

--- a/FElib/src/element/scale_element_modalfilter.F90
+++ b/FElib/src/element/scale_element_modalfilter.F90
@@ -39,6 +39,7 @@ module scale_element_modalfilter
   !
   type, public :: ModalFilter
     real(RP), allocatable :: FilterMat(:,:)
+    real(RP), allocatable :: newMat(:,:)
   contains
     procedure :: Init_line => ModalFilter_Init_line
     procedure :: Init_quadrilateral => ModalFilter_Init_quadrilateral
@@ -168,6 +169,7 @@ contains
       tend_flag_ )                                               ! (in)
 
     allocate( this%FilterMat(elem%Np,elem%Np) )
+    allocate( this%newMat(8,8) )
     this%FilterMat(:,:) = 0.0_RP
     do p3=1, elem%Nnode_v
     do p2=1, elem%Nnode_h1D
@@ -190,6 +192,7 @@ contains
     !--------------------------------------------
 
     if( allocated(this%FilterMat) ) deallocate( this%FilterMat )
+    if( allocated(this%newMat) ) deallocate( this%newMat )
     
     return
   end subroutine ModalFilter_Final

--- a/FElib/src/element/scale_element_modalfilter_orig.F90
+++ b/FElib/src/element/scale_element_modalfilter_orig.F90
@@ -1,0 +1,233 @@
+!-------------------------------------------------------------------------------
+!> module FElib / element/ ModalFilter
+!!
+!! @par Description
+!!      Modal filter
+!!
+!! @author Team SCALE
+!<
+!-------------------------------------------------------------------------------
+#include "scaleFElib.h"
+module scale_element_modalfilter
+  !-----------------------------------------------------------------------------
+  !
+  !++ Used modules
+  !
+  use scale_precision
+  use scale_io
+  use scale_prc
+  use scale_prof
+
+  use scale_element_base, only: &
+    ElementBase1D, ElementBase2D, ElementBase3D
+  
+  use scale_element_line, only: LineElement
+  use scale_element_quadrilateral, only: QuadrilateralElement
+  use scale_element_hexahedral, only: HexahedralElement
+
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public procedures
+  !
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public type
+  !
+  type, public :: ModalFilter
+    real(RP), allocatable :: FilterMat(:,:)
+  contains
+    procedure :: Init_line => ModalFilter_Init_line
+    procedure :: Init_quadrilateral => ModalFilter_Init_quadrilateral
+    procedure :: Init_hexahedral => ModalFilter_Init_hexahedral
+    generic :: Init => Init_line, Init_quadrilateral, Init_hexahedral
+    procedure :: Final => ModalFilter_Final
+  end type ModalFilter
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedures & variables
+  !
+  !-------------------
+
+  private :: get_exp_filter
+
+contains
+  subroutine ModalFilter_Init_line( this,  & ! (inout)
+    elem,                                  & ! (in)
+    etac, alpha, ord,                      & ! (in)
+    tend_flag                              ) ! (in)
+
+    implicit none
+    class(ModalFilter), intent(inout) :: this
+    class(LineElement), intent(in) :: elem
+    real(RP), intent(in) :: etac
+    real(RP), intent(in) :: alpha
+    integer, intent(in) :: ord
+    logical, intent(in), optional :: tend_flag
+
+    real(RP) :: filter1D(elem%Np)
+    integer :: p
+    logical :: tend_flag_
+    !----------------------------------------------------
+    
+    tend_flag_ = .false.
+    if ( present(tend_flag) ) tend_flag_ =  tend_flag
+
+    call get_exp_filter( filter1D,               & ! (out)
+      etac, alpha, ord, elem%Np, elem%PolyOrder, & ! (in)
+      tend_flag_ )                                 ! (in)
+
+    allocate( this%FilterMat(elem%Np,elem%Np) )
+    this%FilterMat(:,:) = 0.0_RP
+    do p=1, elem%Np
+      this%FilterMat(p,p) = filter1D(p)
+    end do
+    this%FilterMat(:,:) = matmul(this%FilterMat, elem%invV)
+    this%FilterMat(:,:) = matmul(elem%V, this%FilterMat)
+    
+    return
+  end subroutine ModalFilter_Init_line
+
+  subroutine ModalFilter_Init_quadrilateral( this,   & ! (inout)
+    elem,                                            & ! (in)
+    etac, alpha, ord,                                & ! (in)
+    tend_flag                                        ) ! (in)
+
+    implicit none
+    class(ModalFilter), intent(inout) :: this
+    class(QuadrilateralElement), intent(in) :: elem
+    real(RP), intent(in) :: etac
+    real(RP), intent(in) :: alpha
+    integer, intent(in) :: ord
+    logical, intent(in), optional :: tend_flag
+
+    real(RP) :: filter1D(elem%Nfp)
+    integer :: p1, p2
+    integer :: l
+    logical :: tend_flag_
+    !----------------------------------------------------
+    
+    tend_flag_ = .false.
+    if ( present(tend_flag) ) tend_flag_ =  tend_flag
+
+    call get_exp_filter( filter1D,                & ! (out)
+      etac, alpha, ord, elem%Nfp, elem%PolyOrder, & ! (in)
+      tend_flag_ )                                  ! (in)
+    
+    allocate( this%FilterMat(elem%Np,elem%Np) )
+    this%FilterMat(:,:) = 0.0_RP
+    do p2=1, elem%Nfp
+    do p1=1, elem%Nfp
+      l = p1 + (p2-1)*elem%Nfp
+      this%FilterMat(l,l) = filter1D(p1) * filter1D(p2)
+    end do  
+    end do
+    this%FilterMat(:,:) = matmul(this%FilterMat, elem%invV)
+    this%FilterMat(:,:) = matmul(elem%V, this%FilterMat)
+    
+    return
+  end subroutine ModalFilter_Init_quadrilateral
+
+  subroutine ModalFilter_Init_hexahedral( this,  & ! (inout)
+    elem,                                        & ! (in)
+    etac_h, alpha_h, ord_h,                      & ! (in)
+    etac_v, alpha_v, ord_v,                      & ! (in)
+    tend_flag                                    ) ! (in)
+
+    implicit none
+    class(ModalFilter), intent(inout) :: this
+    class(HexahedralElement), intent(in) :: elem
+    real(RP), intent(in) :: etac_h
+    real(RP), intent(in) :: alpha_h
+    integer, intent(in) :: ord_h
+    real(RP), intent(in) :: etac_v
+    real(RP), intent(in) :: alpha_v
+    integer, intent(in) :: ord_v
+    logical, intent(in), optional :: tend_flag
+
+    real(RP) :: filter1D_h(elem%Nnode_h1D)
+    real(RP) :: filter1D_v(elem%Nnode_v)
+    integer :: p1, p2, p3
+    integer :: l
+    logical :: tend_flag_
+    !----------------------------------------------------
+    
+    tend_flag_ = .false.
+    if ( present(tend_flag) ) tend_flag_ =  tend_flag
+
+    call get_exp_filter( filter1D_h,                            & ! (out)
+      etac_h, alpha_h, ord_h, elem%Nnode_h1D, elem%PolyOrder_h, & ! (in)
+      tend_flag_ )                                                ! (in)
+    
+    call get_exp_filter( filter1D_v,                           & ! (out)
+      etac_v, alpha_v, ord_V, elem%Nnode_v, elem%PolyOrder_v,  & ! (in)
+      tend_flag_ )                                               ! (in)
+
+    allocate( this%FilterMat(elem%Np,elem%Np) )
+    this%FilterMat(:,:) = 0.0_RP
+    do p3=1, elem%Nnode_v
+    do p2=1, elem%Nnode_h1D
+    do p1=1, elem%Nnode_h1D
+      l = p1 + (p2-1)*elem%Nnode_h1D + (p3-1)*elem%Nnode_h1D**2
+      this%FilterMat(l,l) = filter1D_h(p1) * filter1D_h(p2) * filter1D_v(p3)
+    end do  
+    end do
+    end do
+    this%FilterMat(:,:) = matmul(this%FilterMat, elem%invV)
+    this%FilterMat(:,:) = matmul(elem%V, this%FilterMat)
+    
+    return
+  end subroutine ModalFilter_Init_hexahedral
+
+  subroutine ModalFilter_Final( this )
+    implicit none
+
+    class(ModalFilter), intent(inout) :: this
+    !--------------------------------------------
+
+    if( allocated(this%FilterMat) ) deallocate( this%FilterMat )
+    
+    return
+  end subroutine ModalFilter_Final
+
+!-- private --------------------------------------------------
+
+  subroutine get_exp_filter( filter, &  
+    etac, alpha, ord, Np, polyOrder, &
+    tend_flag )
+
+    implicit none
+    integer, intent(in) :: Np
+    real(RP), intent(out) :: filter(Np)
+    real(RP), intent(in) :: etac  
+    real(RP), intent(in) :: alpha
+    integer , intent(in) :: ord
+    integer , intent(in) :: polyOrder
+    logical, intent(in) :: tend_flag
+
+    integer :: p
+    real(RP) :: eta
+    !-----------------------------------------
+
+    if ( tend_flag ) then
+      filter(:) = 0.0_RP
+    else
+      filter(:) = 1.0_RP
+    end if
+
+    do p=1, Np
+      eta = dble(p-1)/dble(polyOrder)
+      if ( eta >  etac .and. p /= 1) then
+        filter(p) = - alpha * ( ((eta - etac)/(1.0_RP - etac))**ord )
+        if ( .not. tend_flag ) filter(p) = exp( filter(p) )
+      end if
+    end do
+
+    return
+  end subroutine get_exp_filter
+
+end module scale_element_modalfilter

--- a/FElib/src/element/scale_element_modalfilter_tune1.F90
+++ b/FElib/src/element/scale_element_modalfilter_tune1.F90
@@ -1,0 +1,257 @@
+!-------------------------------------------------------------------------------
+!> module FElib / element/ ModalFilter
+!!
+!! @par Description
+!!      Modal filter
+!!
+!! @author Team SCALE
+!<
+!-------------------------------------------------------------------------------
+#include "scaleFElib.h"
+module scale_element_modalfilter
+  !-----------------------------------------------------------------------------
+  !
+  !++ Used modules
+  !
+  use scale_precision
+  use scale_io
+  use scale_prc
+  use scale_prof
+
+  use scale_element_base, only: &
+    ElementBase1D, ElementBase2D, ElementBase3D
+  
+  use scale_element_line, only: LineElement
+  use scale_element_quadrilateral, only: QuadrilateralElement
+  use scale_element_hexahedral, only: HexahedralElement
+
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public procedures
+  !
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public type
+  !
+  type, public :: ModalFilter
+    real(RP), allocatable :: FilterMat(:,:)
+  contains
+    procedure :: Init_line => ModalFilter_Init_line
+    procedure :: Init_quadrilateral => ModalFilter_Init_quadrilateral
+    procedure :: Init_hexahedral => ModalFilter_Init_hexahedral
+    generic :: Init => Init_line, Init_quadrilateral, Init_hexahedral
+    procedure :: Final => ModalFilter_Final
+  end type ModalFilter
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedures & variables
+  !
+  !-------------------
+
+  private :: get_exp_filter
+
+contains
+  subroutine ModalFilter_Init_line( this,  & ! (inout)
+    elem,                                  & ! (in)
+    etac, alpha, ord,                      & ! (in)
+    tend_flag                              ) ! (in)
+
+    implicit none
+    class(ModalFilter), intent(inout) :: this
+    class(LineElement), intent(in) :: elem
+    real(RP), intent(in) :: etac
+    real(RP), intent(in) :: alpha
+    integer, intent(in) :: ord
+    logical, intent(in), optional :: tend_flag
+
+    real(RP) :: filter1D(elem%Np)
+    integer :: p
+    logical :: tend_flag_
+    !----------------------------------------------------
+    
+    tend_flag_ = .false.
+    if ( present(tend_flag) ) tend_flag_ =  tend_flag
+
+    call get_exp_filter( filter1D,               & ! (out)
+      etac, alpha, ord, elem%Np, elem%PolyOrder, & ! (in)
+      tend_flag_ )                                 ! (in)
+
+    allocate( this%FilterMat(elem%Np,elem%Np) )
+    this%FilterMat(:,:) = 0.0_RP
+    do p=1, elem%Np
+      this%FilterMat(p,p) = filter1D(p)
+    end do
+    this%FilterMat(:,:) = matmul(this%FilterMat, elem%invV)
+    this%FilterMat(:,:) = matmul(elem%V, this%FilterMat)
+    
+    return
+  end subroutine ModalFilter_Init_line
+
+  subroutine ModalFilter_Init_quadrilateral( this,   & ! (inout)
+    elem,                                            & ! (in)
+    etac, alpha, ord,                                & ! (in)
+    tend_flag                                        ) ! (in)
+
+    implicit none
+    class(ModalFilter), intent(inout) :: this
+    class(QuadrilateralElement), intent(in) :: elem
+    real(RP), intent(in) :: etac
+    real(RP), intent(in) :: alpha
+    integer, intent(in) :: ord
+    logical, intent(in), optional :: tend_flag
+
+    real(RP) :: filter1D(elem%Nfp)
+    integer :: p1, p2
+    integer :: l
+    logical :: tend_flag_
+    !----------------------------------------------------
+    
+    tend_flag_ = .false.
+    if ( present(tend_flag) ) tend_flag_ =  tend_flag
+
+    call get_exp_filter( filter1D,                & ! (out)
+      etac, alpha, ord, elem%Nfp, elem%PolyOrder, & ! (in)
+      tend_flag_ )                                  ! (in)
+    
+    allocate( this%FilterMat(elem%Np,elem%Np) )
+    this%FilterMat(:,:) = 0.0_RP
+    do p2=1, elem%Nfp
+    do p1=1, elem%Nfp
+      l = p1 + (p2-1)*elem%Nfp
+      this%FilterMat(l,l) = filter1D(p1) * filter1D(p2)
+    end do  
+    end do
+    this%FilterMat(:,:) = matmul(this%FilterMat, elem%invV)
+    this%FilterMat(:,:) = matmul(elem%V, this%FilterMat)
+    
+    return
+  end subroutine ModalFilter_Init_quadrilateral
+
+  subroutine ModalFilter_Init_hexahedral( this,  & ! (inout)
+    elem,                                        & ! (in)
+    etac_h, alpha_h, ord_h,                      & ! (in)
+    etac_v, alpha_v, ord_v,                      & ! (in)
+    tend_flag                                    ) ! (in)
+
+    implicit none
+    class(ModalFilter), intent(inout) :: this
+    class(HexahedralElement), intent(in) :: elem
+    real(RP), intent(in) :: etac_h
+    real(RP), intent(in) :: alpha_h
+    integer, intent(in) :: ord_h
+    real(RP), intent(in) :: etac_v
+    real(RP), intent(in) :: alpha_v
+    integer, intent(in) :: ord_v
+    logical, intent(in), optional :: tend_flag
+
+    real(RP) :: filter1D_h(elem%Nnode_h1D)
+    real(RP) :: filter1D_v(elem%Nnode_v)
+    !--- for 3 direction
+    !--- should create 1D_h and 1D_v, just for simplicity
+    type(LineElement) :: elem1D
+    !--- end
+    integer :: p1, p2, p3
+    integer :: l
+    logical :: tend_flag_
+    !----------------------------------------------------
+    
+    tend_flag_ = .false.
+    if ( present(tend_flag) ) tend_flag_ =  tend_flag
+
+    call get_exp_filter( filter1D_h,                            & ! (out)
+      etac_h, alpha_h, ord_h, elem%Nnode_h1D, elem%PolyOrder_h, & ! (in)
+      tend_flag_ )                                                ! (in)
+    
+    call get_exp_filter( filter1D_v,                           & ! (out)
+      etac_v, alpha_v, ord_V, elem%Nnode_v, elem%PolyOrder_v,  & ! (in)
+      tend_flag_ )                                               ! (in)
+
+    ! -- original method
+    !allocate( this%FilterMat(elem%Np,elem%Np) )
+    !this%FilterMat(:,:) = 0.0_RP
+
+    !do p3=1, elem%Nnode_v
+    !do p2=1, elem%Nnode_h1D
+    !do p1=1, elem%Nnode_h1D
+    !  l = p1 + (p2-1)*elem%Nnode_h1D + (p3-1)*elem%Nnode_h1D**2
+    !  this%FilterMat(l,l) = filter1D_h(p1) * filter1D_h(p2) * filter1D_v(p3)
+    !end do  
+    !end do
+    !end do
+    !this%FilterMat(:,:) = matmul(this%FilterMat, elem%invV)
+    !this%FilterMat(:,:) = matmul(elem%V, this%FilterMat)
+
+    !--- init a line element
+    call elem1D%Init(elem%PolyOrder_h, .false.)
+
+    allocate( this%FilterMat(elem1D%Np,elem1D%Np) )
+    this%FilterMat(:,:) = 0.0_RP
+
+    !--- assgin 1d filter to the matrix
+    do p1=1, elem1D%Np
+      this%FilterMat(p1,p1) = filter1D_h(p1)
+    end do
+
+    this%FilterMat(:,:) = matmul(this%FilterMat, elem1D%invV)
+    this%FilterMat(:,:) = matmul(elem1D%V, this%FilterMat)
+
+    !-- clean up
+
+    call elem1D%Final()
+
+    return
+  end subroutine ModalFilter_Init_hexahedral
+
+  subroutine ModalFilter_Final( this )
+    implicit none
+
+    class(ModalFilter), intent(inout) :: this
+    !--------------------------------------------
+
+    if( allocated(this%FilterMat) ) deallocate( this%FilterMat )
+    
+    return
+  end subroutine ModalFilter_Final
+
+!-- private --------------------------------------------------
+
+  subroutine get_exp_filter( filter, &  
+    etac, alpha, ord, Np, polyOrder, &
+    tend_flag )
+
+    implicit none
+    integer, intent(in) :: Np
+    real(RP), intent(out) :: filter(Np)
+    real(RP), intent(in) :: etac  
+    real(RP), intent(in) :: alpha
+    integer , intent(in) :: ord
+    integer , intent(in) :: polyOrder
+    logical, intent(in) :: tend_flag
+
+    integer :: p
+    real(RP) :: eta
+    !-----------------------------------------
+
+    if ( tend_flag ) then
+      filter(:) = 0.0_RP
+    else
+      filter(:) = 1.0_RP
+    end if
+
+    do p=1, Np
+      eta = dble(p-1)/dble(polyOrder)
+      if ( eta >  etac .and. p /= 1) then
+        filter(p) = - alpha * ( ((eta - etac)/(1.0_RP - etac))**ord )
+        if ( .not. tend_flag ) filter(p) = exp( filter(p) )
+      end if
+    end do
+
+    return
+  end subroutine get_exp_filter
+
+end module scale_element_modalfilter

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve_orig.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve_orig.F90
@@ -1,0 +1,574 @@
+!-------------------------------------------------------------------------------
+!> module FElib / Fluid dyn solver / Atmosphere / Global nonhydrostatic model / HEVE
+!!
+!! @par Description
+!!      HEVE DGM scheme for Global Atmospheric Dynamical process. 
+!!      The governing equations is a fully compressibile nonhydrostic equations, 
+!!      which consist of mass, momentum, and thermodynamics (density * potential temperature conservation) equations. 
+!!
+!! @author Team SCALE
+!<
+!-------------------------------------------------------------------------------
+#include "scaleFElib.h"
+module scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve
+  !-----------------------------------------------------------------------------
+  !
+  !++ Used modules
+  !
+  use scale_precision
+  use scale_io
+  use scale_prc
+  use scale_prof
+  use scale_const, only: &
+    GRAV => CONST_GRAV,    &
+    Rdry => CONST_Rdry,    &
+    CPdry => CONST_CPdry,  &
+    CVdry => CONST_CVdry,  &
+    PRES00 => CONST_PRE00, &
+    RPlanet => CONST_RADIUS
+
+  use scale_sparsemat  
+  use scale_element_base, only: &
+    ElementBase2D, ElementBase3D
+  use scale_element_hexahedral, only: HexahedralElement
+  use scale_localmesh_2d, only: LocalMesh2D  
+  use scale_localmesh_3d, only: LocalMesh3D
+  use scale_mesh_base2d, only: MeshBase2D
+  use scale_mesh_base3d, only: MeshBase3D
+  use scale_localmeshfield_base, only: LocalMeshField3D
+  use scale_meshfield_base, only: MeshField3D
+
+  use scale_atm_dyn_dgm_nonhydro3d_common, only: &
+    atm_dyn_dgm_nonhydro3d_common_Init,                       &
+    atm_dyn_dgm_nonhydro3d_common_Final,                      &
+    DENS_VID => PRGVAR_DDENS_ID, RHOT_VID => PRGVAR_DRHOT_ID, &
+    MOMX_VID => PRGVAR_MOMX_ID, MOMY_VID => PRGVAR_MOMY_ID,   &
+    MOMZ_VID => PRGVAR_MOMZ_ID,                               &
+    PRGVAR_NUM, IntrpMat_VPOrdM1
+  
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public procedures
+  !
+  public :: atm_dyn_dgm_globalnonhydro3d_rhot_heve_Init
+  public :: atm_dyn_dgm_globalnonhydro3d_rhot_heve_Final
+  public :: atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_shallow_atm
+  public :: atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_deep_atm
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public parameters & variables
+  !
+  
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedures & variables
+  !
+  !-------------------
+
+contains
+!OCL SERIAL
+  subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_Init( mesh )
+    implicit none
+    class(MeshBase3D), intent(in) :: mesh
+    !--------------------------------------------
+
+    call atm_dyn_dgm_nonhydro3d_common_Init( mesh )
+
+    return
+  end subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_Init
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_Final()
+    implicit none
+    !--------------------------------------------
+    
+    call atm_dyn_dgm_nonhydro3d_common_Final()    
+    return
+  end subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_Final  
+
+  !-------------------------------
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_shallow_atm( &
+    DENS_dt, MOMX_dt, MOMY_dt, MOMZ_dt, RHOT_dt,                                & ! (out)
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd, CORIOLIS,  & ! (in)
+    Rtot, CVtot, CPtot,                                                         & ! (in)
+    Dx, Dy, Dz, Sx, Sy, Sz, Lift, lmesh, elem, lmesh2D, elem2D )                  ! (in)
+
+    use scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux, only: &
+      get_ebnd_flux => atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalhvc
+    use scale_const, only: &
+      OHM => CONST_OHM
+    implicit none
+
+    class(LocalMesh3D), intent(in) :: lmesh
+    class(ElementBase3D), intent(in) :: elem
+    class(LocalMesh2D), intent(in) :: lmesh2D
+    class(ElementBase2D), intent(in) :: elem2D
+    type(SparseMat), intent(in) :: Dx, Dy, Dz, Sx, Sy, Sz, Lift
+    real(RP), intent(out) :: DENS_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMX_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMY_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMZ_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: RHOT_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DDENS_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMX_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMY_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMZ_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DRHOT_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DPRES_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DENS_hyd(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: PRES_hyd(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: CORIOLIS(elem2D%Np,lmesh2D%NeA)
+    real(RP), intent(in)  :: Rtot (elem%Np,lmesh%NeA)    
+    real(RP), intent(in)  :: CVtot(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: CPtot(elem%Np,lmesh%NeA)
+
+    real(RP) :: Fx(elem%Np), Fy(elem%Np), Fz(elem%Np), LiftDelFlx(elem%Np)
+    real(RP) :: GradPhyd_x(elem%Np), GradPhyd_y(elem%Np)
+    real(RP) :: del_flux(elem%NfpTot,lmesh%Ne,PRGVAR_NUM)
+    real(RP) :: del_flux_hyd(elem%NfpTot,lmesh%Ne,2)
+    real(RP) :: RHOT_(elem%Np)
+    real(RP) :: rdens_(elem%Np), u_(elem%Np), v_(elem%Np), w_(elem%Np), wt_(elem%np), drho(elem%Np)
+
+    real(RP) :: G11(elem%Np), G12(elem%Np), G22(elem%Np)
+    real(RP) :: GsqrtV(elem%Np), RGsqrtV(elem%Np)
+    real(RP) :: X2D(elem2D%Np,lmesh2D%Ne), Y2D(elem2D%Np,lmesh2D%Ne)
+    real(RP) :: X(elem%Np), Y(elem%Np), twoOVdel2(elem%Np)
+    real(RP) :: CORI(elem%Np,2)
+    logical :: is_panel1to4
+    real(RP) :: s
+
+    integer :: ke, ke2d
+    integer :: p, p12, p3
+
+    real(RP) :: gamm, rgamm    
+    real(RP) :: rP0
+    real(RP) :: RovP0, P0ovR
+    !------------------------------------------------------------------------
+
+    call PROF_rapstart('cal_dyn_tend_bndflux', 3)
+    call get_ebnd_flux( &
+      del_flux, del_flux_hyd,                                                  & ! (out)
+      DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd,         & ! (in)
+      Rtot, CVtot, CPtot,                                                      & ! (in)
+      lmesh%Gsqrt, lmesh%GIJ(:,:,1,1), lmesh%GIJ(:,:,1,2), lmesh%GIJ(:,:,2,2), & ! (in)
+      lmesh%GsqrtH, lmesh%gam, lmesh%GI3(:,:,1), lmesh%GI3(:,:,2),             & ! (in)    
+      lmesh%normal_fn(:,:,1), lmesh%normal_fn(:,:,2), lmesh%normal_fn(:,:,3),  & ! (in)
+      lmesh%vmapM, lmesh%vmapP, elem%IndexH2Dto3D_bnd,                         & ! (in)
+      lmesh, elem, lmesh2D, elem2D                                             ) ! (in)
+    call PROF_rapend('cal_dyn_tend_bndflux', 3)
+ 
+    !-----
+    call PROF_rapstart('cal_dyn_tend_interior', 3)
+    gamm  = CPDry / CvDry
+    rgamm = CvDry / CpDry
+    rP0   = 1.0_RP / PRES00
+    RovP0 = Rdry * rP0
+    P0ovR = PRES00 / Rdry
+
+    s = 1.0_RP 
+    is_panel1to4 = .true.
+    if ( lmesh%panelID == 5 ) then
+      is_panel1to4 = .false.
+    else if ( lmesh%panelID == 6 ) then
+      is_panel1to4 = .false.
+      s = - 1.0_RP
+    end if
+
+    !$omp parallel private(                        &
+    !$omp RHOT_, rdens_, u_, v_, w_, wt_,          &
+    !$omp Fx, Fy, Fz, LiftDelFlx,                  &
+    !$omp drho, GradPhyd_x, GradPhyd_y,            &
+    !$omp G11, G12, G22, GsqrtV, RGsqrtV,          &
+    !$omp X, Y, twoOVdel2,                         &
+    !$omp CORI, ke, ke2D                           )
+
+    !$omp do
+    do ke2D = lmesh2D%NeS, lmesh2D%NeE
+      X2D(:,ke2d) = tan(lmesh2D%pos_en(:,ke2d,1))
+      Y2D(:,ke2d) = tan(lmesh2D%pos_en(:,ke2d,2))
+    end do
+
+    !$omp do
+    do ke = lmesh%NeS, lmesh%NeE
+      !--
+      ke2d = lmesh%EMap3Dto2D(ke)
+      G11(:) = lmesh%GIJ(elem%IndexH2Dto3D,ke2d,1,1)
+      G12(:) = lmesh%GIJ(elem%IndexH2Dto3D,ke2d,1,2)
+      G22(:) = lmesh%GIJ(elem%IndexH2Dto3D,ke2d,2,2)
+      GsqrtV(:)  = lmesh%Gsqrt(:,ke) / lmesh%GsqrtH(elem%IndexH2Dto3D,ke2d)
+      RGsqrtV(:) = 1.0_RP / GsqrtV(:)
+
+      !--
+      RHOT_(:) = P0ovR * ( PRES_hyd(:,ke) * rP0 )**rgamm + DRHOT_(:,ke)
+      ! DPRES_(:) = PRES00 * ( Rtot(:,ke) * rP0 * RHOT_(:) )**( CPtot(:,ke) / CVtot(:,ke) ) &
+      !           - PRES_hyd(:,ke)
+
+      rdens_(:) = 1.0_RP / ( DDENS_(:,ke) + DENS_hyd(:,ke) )
+      u_ (:) = MOMX_(:,ke) * rdens_(:)
+      v_ (:) = MOMY_(:,ke) * rdens_(:)
+      w_ (:) = MOMZ_(:,ke) * rdens_(:)
+      wt_(:) = w_(:) * RGsqrtV(:) + lmesh%GI3(:,ke,1) * u_(:) + lmesh%GI3(:,ke,2) * v_(:) 
+
+      X(:) = X2D(elem%IndexH2Dto3D,ke2d)
+      Y(:) = Y2D(elem%IndexH2Dto3D,ke2d)
+      twoOVdel2(:) = 2.0_RP / ( 1.0_RP + X(:)**2 + Y(:)**2 )
+
+      CORI(:,1) = s * OHM * twoOVdel2(:) * ( - X(:) * Y(:)          * MOMX_(:,ke) + ( 1.0_RP + Y(:)**2 ) * MOMY_(:,ke) )
+      CORI(:,2) = s * OHM * twoOVdel2(:) * ( - ( 1.0_RP + X(:)**2 ) * MOMX_(:,ke) +  X(:) * Y(:)         * MOMY_(:,ke) )
+      if ( is_panel1to4 ) then
+        CORI(:,1) = s * Y(:) * CORI(:,1)
+        CORI(:,2) = s * Y(:) * CORI(:,2)
+      end if
+
+      drho(:) = matmul(IntrpMat_VPOrdM1, DDENS_(:,ke))
+
+      !-- Gradient hydrostatic pressure
+      
+      call sparsemat_matmul(Dx, GsqrtV(:) * PRES_hyd(:,ke), Fx)
+      call sparsemat_matmul(Dz, GsqrtV(:) * lmesh%GI3(:,ke,1) * PRES_hyd(:,ke), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux_hyd(:,ke,1), LiftDelFlx)
+      GradPhyd_x(:) = lmesh%Escale(:,ke,1,1) * Fx(:) &
+                    + lmesh%Escale(:,ke,3,3) * Fz(:) &
+                    + LiftDelFlx(:)
+
+      call sparsemat_matmul(Dy, GsqrtV(:) * PRES_hyd(:,ke), Fy)
+      call sparsemat_matmul(Dz, GsqrtV(:) * lmesh%GI3(:,ke,2) * PRES_hyd(:,ke), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux_hyd(:,ke,2), LiftDelFlx)
+      GradPhyd_y(:) = lmesh%Escale(:,ke,2,2) * Fy(:) &
+                    + lmesh%Escale(:,ke,3,3) * Fz(:) &
+                    + LiftDelFlx(:)
+      
+      !-- DENS
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * MOMX_(:,ke), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * MOMY_(:,ke), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( DDENS_(:,ke) + DENS_hyd(:,ke) ) * wt_(:), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,DENS_VID), LiftDelFlx)
+
+      DENS_dt(:,ke) = - ( &
+            lmesh%Escale(:,ke,1,1) * Fx(:)     &
+          + lmesh%Escale(:,ke,2,2) * Fy(:)     &
+          + lmesh%Escale(:,ke,3,3) * Fz(:)     &
+          + LiftDelFlx(:) ) / lmesh%Gsqrt(:,ke)
+      
+      !-- MOMX
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * ( u_ (:) * MOMX_(:,ke) + G11(:) * DPRES_(:,ke) ), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * ( v_ (:) * MOMX_(:,ke) + G12(:) * DPRES_(:,ke) ), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( wt_(:) * MOMX_(:,ke)                              &
+                                                    + ( lmesh%GI3(:,ke,1) * G11(:) + lmesh%GI3(:,ke,2) * G12(:) ) * DPRES_(:,ke) ), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,MOMX_VID), LiftDelFlx)
+
+      MOMX_dt(:,ke) = &
+          - ( lmesh%Escale(:,ke,1,1) * Fx(:)                                         &
+            + lmesh%Escale(:,ke,2,2) * Fy(:)                                         &
+            + lmesh%Escale(:,ke,3,3) * Fz(:)                                         &
+            + LiftDelFlx(:)                   ) / lmesh%Gsqrt(:,ke)                  &
+          - twoOVdel2(:) * Y(:) *                                                    &
+            ( X(:) * Y(:) * u_(:) - (1.0_RP + Y(:)**2) * v_(:) ) * MOMX_(:,ke)       &
+          - ( G11(:) * GradPhyd_x(:) + G12(:) * GradPhyd_y(:) ) * RGsqrtV(:)         &
+          + CORI(:,1)              
+
+      !-- MOMY
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * ( u_ (:) * MOMY_(:,ke) + G12(:) * DPRES_(:,ke) ), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * ( v_ (:) * MOMY_(:,ke) + G22(:) * DPRES_(:,ke) ), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( wt_(:) * MOMY_(:,ke)                              &
+                                                    + ( lmesh%GI3(:,ke,1) * G12(:) + lmesh%GI3(:,ke,2) * G22(:) ) * DPRES_(:,ke) ), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,MOMY_VID), LiftDelFlx)
+
+      MOMY_dt(:,ke) = &
+            - ( lmesh%Escale(:,ke,1,1) * Fx(:)                                         &
+              + lmesh%Escale(:,ke,2,2) * Fy(:)                                         &
+              + lmesh%Escale(:,ke,3,3) * Fz(:)                                         &
+              + LiftDelFlx(:)                  ) / lmesh%Gsqrt(:,ke)                   &
+            - twoOVdel2(:) * X(:) *                                                    &
+              ( - (1.0_RP + X(:)**2) * u_(:) + X(:) * Y(:) * v_(:) ) * MOMY_(:,ke)     &
+            - ( G12(:) * GradPhyd_x(:) + G22(:) * GradPhyd_y(:) ) * RGsqrtV(:)         &
+            + CORI(:,2) 
+
+      !-- MOMZ
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) *   u_ (:) * MOMZ_(:,ke), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) *   v_ (:) * MOMZ_(:,ke), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( wt_(:) * MOMZ_(:,ke) + RGsqrtV(:) * DPRES_(:,ke) ), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,MOMZ_VID), LiftDelFlx)
+      
+      MOMZ_dt(:,ke) = &
+          - ( lmesh%Escale(:,ke,1,1) * Fx(:)       &
+            + lmesh%Escale(:,ke,2,2) * Fy(:)       &
+            + lmesh%Escale(:,ke,3,3) * Fz(:)       &
+            + LiftDelFlx(:) ) / lmesh%Gsqrt(:,ke)  &
+          - Grav * drho(:)
+
+      !-- RHOT
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * u_ (:) * RHOT_(:), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * v_ (:) * RHOT_(:), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * wt_(:) * RHOT_(:), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,RHOT_VID), LiftDelFlx)
+      
+      RHOT_dt(:,ke) = &
+          - ( lmesh%Escale(:,ke,1,1) * Fx(:)      &
+            + lmesh%Escale(:,ke,2,2) * Fy(:)      &
+            + lmesh%Escale(:,ke,3,3) * Fz(:)      &
+            + LiftDelFlx(:) ) / lmesh%Gsqrt(:,ke) 
+    
+    end do
+    !$omp end do
+    !$omp end parallel
+    call PROF_rapend('cal_dyn_tend_interior', 3)
+
+    return
+  end subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_shallow_atm
+
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_deep_atm( &
+    DENS_dt, MOMX_dt, MOMY_dt, MOMZ_dt, RHOT_dt,                                & ! (out)
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd, CORIOLIS,  & ! (in)
+    Rtot, CVtot, CPtot,                                                         & ! (in)
+    Dx, Dy, Dz, Sx, Sy, Sz, Lift, lmesh, elem, lmesh2D, elem2D )                  ! (in)
+
+    use scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux, only: &
+      get_ebnd_flux => atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalhvc
+    use scale_const, only: &
+      OHM => CONST_OHM
+    implicit none
+
+    class(LocalMesh3D), intent(in) :: lmesh
+    class(ElementBase3D), intent(in) :: elem
+    class(LocalMesh2D), intent(in) :: lmesh2D
+    class(ElementBase2D), intent(in) :: elem2D
+    type(SparseMat), intent(in) :: Dx, Dy, Dz, Sx, Sy, Sz, Lift
+    real(RP), intent(out) :: DENS_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMX_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMY_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMZ_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: RHOT_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DDENS_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMX_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMY_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMZ_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DRHOT_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DPRES_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DENS_hyd(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: PRES_hyd(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: CORIOLIS(elem2D%Np,lmesh2D%NeA)
+    real(RP), intent(in)  :: Rtot (elem%Np,lmesh%NeA)    
+    real(RP), intent(in)  :: CVtot(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: CPtot(elem%Np,lmesh%NeA)
+
+    real(RP) :: Fx(elem%Np), Fy(elem%Np), Fz(elem%Np), LiftDelFlx(elem%Np)
+    real(RP) :: GradPhyd_x(elem%Np), GradPhyd_y(elem%Np)
+    real(RP) :: del_flux(elem%NfpTot,lmesh%Ne,PRGVAR_NUM)
+    real(RP) :: del_flux_hyd(elem%NfpTot,lmesh%Ne,2)
+    real(RP) :: RHOT_(elem%Np)
+    real(RP) :: rdens_(elem%Np), u_(elem%Np), v_(elem%Np), w_(elem%Np), wt_(elem%np), drho(elem%Np)
+
+    real(RP) :: G11(elem%Np), G12(elem%Np), G22(elem%Np)
+    real(RP) :: GsqrtV(elem%Np), RGsqrtV(elem%Np), Rgam2(elem%Np)
+    real(RP) :: X2D(elem2D%Np,lmesh2D%Ne), Y2D(elem2D%Np,lmesh2D%Ne)
+    real(RP) :: X(elem%Np), Y(elem%Np), twoOVdel2(elem%Np)
+    real(RP) :: OM1(elem%Np), OM2(elem%Np), OM3(elem%Np), DEL(elem%Np), R(elem%Np)
+    logical :: is_panel1to4
+    real(RP) :: s
+
+    integer :: ke, ke2d
+    integer :: p
+    
+    real(RP) :: rgamm    
+    real(RP) :: rP0
+    real(RP) :: P0ovR
+    !------------------------------------------------------------------------
+
+    call PROF_rapstart('cal_dyn_tend_bndflux', 3)
+    call get_ebnd_flux( &
+      del_flux, del_flux_hyd,                                                  & ! (out)
+      DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd,         & ! (in)
+      Rtot, CVtot, CPtot,                                                      & ! (in)
+      lmesh%Gsqrt, lmesh%GIJ(:,:,1,1), lmesh%GIJ(:,:,1,2), lmesh%GIJ(:,:,2,2), & ! (in)
+      lmesh%GsqrtH, lmesh%gam, lmesh%GI3(:,:,1), lmesh%GI3(:,:,2),             & ! (in)    
+      lmesh%normal_fn(:,:,1), lmesh%normal_fn(:,:,2), lmesh%normal_fn(:,:,3),  & ! (in)
+      lmesh%vmapM, lmesh%vmapP, elem%IndexH2Dto3D_bnd,                         & ! (in)
+      lmesh, elem, lmesh2D, elem2D                                             ) ! (in)
+    call PROF_rapend('cal_dyn_tend_bndflux', 3)
+ 
+    !-----
+    call PROF_rapstart('cal_dyn_tend_interior', 3)
+    rgamm = CvDry / CpDry
+    rP0   = 1.0_RP / PRES00
+    P0ovR = PRES00 / Rdry
+
+    s = 2.0_RP * OHM
+    is_panel1to4 = .true.
+    if ( lmesh%panelID == 5 ) then
+      is_panel1to4 = .false.
+    else if ( lmesh%panelID == 6 ) then
+      is_panel1to4 = .false.
+      s = - s
+    end if
+
+    !$omp parallel private(                        &
+    !$omp RHOT_, rdens_, u_, v_, w_, wt_,          &
+    !$omp Fx, Fy, Fz, LiftDelFlx,                  &
+    !$omp drho, GradPhyd_x, GradPhyd_y,            &
+    !$omp G11, G12, G22, Rgam2, GsqrtV, RGsqrtV,   &
+    !$omp X, Y, twoOVdel2,                         &
+    !$omp OM1, OM2, OM3, DEL, R, ke, ke2D          )
+
+    !$omp do
+    do ke2D = lmesh2D%NeS, lmesh2D%NeE
+      X2D(:,ke2d) = tan(lmesh2D%pos_en(:,ke2d,1))
+      Y2D(:,ke2d) = tan(lmesh2D%pos_en(:,ke2d,2))
+    end do
+
+    !$omp do
+    do ke = lmesh%NeS, lmesh%NeE
+      !--
+      ke2d = lmesh%EMap3Dto2D(ke)
+      Rgam2(:) = 1.0_RP / lmesh%gam(:,ke)**2
+      G11(:) = lmesh%GIJ(elem%IndexH2Dto3D,ke2d,1,1) * Rgam2(:)
+      G12(:) = lmesh%GIJ(elem%IndexH2Dto3D,ke2d,1,2) * Rgam2(:)
+      G22(:) = lmesh%GIJ(elem%IndexH2Dto3D,ke2d,2,2) * Rgam2(:)
+      GsqrtV(:)  = lmesh%Gsqrt(:,ke) * Rgam2(:) / lmesh%GsqrtH(elem%IndexH2Dto3D,ke2d)
+      RGsqrtV(:) = 1.0_RP / GsqrtV(:)
+
+      !--
+      RHOT_(:) = P0ovR * ( PRES_hyd(:,ke) * rP0 )**rgamm + DRHOT_(:,ke)
+      ! DPRES_(:) = PRES00 * ( Rtot(:,ke) * rP0 * RHOT_(:) )**( CPtot(:,ke) / CVtot(:,ke) ) &
+      !           - PRES_hyd(:,ke)
+
+      rdens_(:) = 1.0_RP / ( DDENS_(:,ke) + DENS_hyd(:,ke) )
+      u_ (:) = MOMX_(:,ke) * rdens_(:)
+      v_ (:) = MOMY_(:,ke) * rdens_(:)
+      w_ (:) = MOMZ_(:,ke) * rdens_(:)
+      wt_(:) = w_(:) * RGsqrtV(:) + lmesh%GI3(:,ke,1) * u_(:) + lmesh%GI3(:,ke,2) * v_(:) 
+
+      X(:) = X2D(elem%IndexH2Dto3D,ke2d)
+      Y(:) = Y2D(elem%IndexH2Dto3D,ke2d)
+      DEL(:) = sqrt( 1.0_RP + X(:)**2 + Y(:)**2 )
+      twoOVdel2(:) = 2.0_RP / ( 1.0_RP + X(:)**2 + Y(:)**2 )
+
+      R(:) = RPlanet * lmesh%gam(:,ke)
+
+      !-  pnl=1~4: OM1:                     0, OM2: s del / (r (1+Y^2)) ,   s OM3 : Y /del
+      !-  pnl=5,6: OM1: - s X del/(r (1+X^2)), OM2: -  s Y del/(r(1+Y^2)), OM3 : s/del
+      if ( is_panel1to4 ) then
+        OM1(:) = 0.0_RP
+        OM2(:) = s * DEL(:) / ( R(:) * ( 1.0_RP + Y(:)**2 ) )
+        OM3(:) = s * Y(:) / DEL(:)
+      else
+        OM1(:) = - s * X(:) * DEL(:) / ( R(:) * ( 1.0_RP + X(:)**2 ) )
+        OM2(:) = - s * Y(:) * DEL(:) / ( R(:) * ( 1.0_RP + Y(:)**2 ) )
+        OM3(:) =   s / DEL(:)
+      end if
+
+      drho(:) = matmul(IntrpMat_VPOrdM1, DDENS_(:,ke))
+
+      !-- Gradient hydrostatic pressure
+      
+      call sparsemat_matmul(Dx, GsqrtV(:) * PRES_hyd(:,ke), Fx)
+      call sparsemat_matmul(Dz, GsqrtV(:) * lmesh%GI3(:,ke,1) * PRES_hyd(:,ke), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux_hyd(:,ke,1), LiftDelFlx)
+      GradPhyd_x(:) = lmesh%Escale(:,ke,1,1) * Fx(:) &
+                    + lmesh%Escale(:,ke,3,3) * Fz(:) &
+                    + LiftDelFlx(:)
+
+      call sparsemat_matmul(Dy, GsqrtV(:) * PRES_hyd(:,ke), Fy)
+      call sparsemat_matmul(Dz, GsqrtV(:) * lmesh%GI3(:,ke,2) * PRES_hyd(:,ke), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux_hyd(:,ke,2), LiftDelFlx)
+      GradPhyd_y(:) = lmesh%Escale(:,ke,2,2) * Fy(:) &
+                    + lmesh%Escale(:,ke,3,3) * Fz(:) &
+                    + LiftDelFlx(:)
+      
+      !-- DENS
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * MOMX_(:,ke), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * MOMY_(:,ke), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( DDENS_(:,ke) + DENS_hyd(:,ke) ) * wt_(:), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,DENS_VID), LiftDelFlx)
+
+      DENS_dt(:,ke) = - ( &
+            lmesh%Escale(:,ke,1,1) * Fx(:)     &
+          + lmesh%Escale(:,ke,2,2) * Fy(:)     &
+          + lmesh%Escale(:,ke,3,3) * Fz(:)     &
+          + LiftDelFlx(:) ) / lmesh%Gsqrt(:,ke)
+      
+      !-- MOMX
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * ( u_ (:) * MOMX_(:,ke) + G11(:) * DPRES_(:,ke) ), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * ( v_ (:) * MOMX_(:,ke) + G12(:) * DPRES_(:,ke) ), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( wt_(:) * MOMX_(:,ke)                              &
+                                                    + ( lmesh%GI3(:,ke,1) * G11(:) + lmesh%GI3(:,ke,2) * G12(:) ) * DPRES_(:,ke) ), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,MOMX_VID), LiftDelFlx)
+
+      MOMX_dt(:,ke) = &
+          - ( lmesh%Escale(:,ke,1,1) * Fx(:)                                                &
+            + lmesh%Escale(:,ke,2,2) * Fy(:)                                                &
+            + lmesh%Escale(:,ke,3,3) * Fz(:)                                                &
+            + LiftDelFlx(:)                   ) / lmesh%Gsqrt(:,ke)                         &
+          - twoOVdel2(:) * Y(:) *                                                           & !-> metric terms
+            ( X(:) * Y(:) * u_(:) - ( 1.0_RP + Y(:)**2 ) * v_(:) ) * MOMX_(:,ke)            & !
+          - 2.0_RP * u_(:) * MOMZ_(:,ke) / R(:)                                             & !<-
+          - ( G11(:) * GradPhyd_x(:) + G12(:) * GradPhyd_y(:) ) * RGsqrtV(:)                & !-> gradient hydrostatic pressure
+          - lmesh%Gsqrt(:,ke) * (  G11(:) * ( OM2(:) * MOMZ_(:,ke) - OM3(:) * MOMY_(:,ke) ) & !-> Coriolis term
+                                 - G12(:) * ( OM1(:) * MOMZ_(:,ke) - OM3(:) * MOMX_(:,ke) ) )
+
+      !-- MOMY
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * ( u_ (:) * MOMY_(:,ke) + G12(:) * DPRES_(:,ke) ), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * ( v_ (:) * MOMY_(:,ke) + G22(:) * DPRES_(:,ke) ), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( wt_(:) * MOMY_(:,ke)                              &
+                                                    + ( lmesh%GI3(:,ke,1) * G12(:) + lmesh%GI3(:,ke,2) * G22(:) ) * DPRES_(:,ke) ), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,MOMY_VID), LiftDelFlx)
+
+      MOMY_dt(:,ke) = &
+            - ( lmesh%Escale(:,ke,1,1) * Fx(:)                                                &
+              + lmesh%Escale(:,ke,2,2) * Fy(:)                                                &
+              + lmesh%Escale(:,ke,3,3) * Fz(:)                                                &
+              + LiftDelFlx(:)                  ) / lmesh%Gsqrt(:,ke)                          &
+            - twoOVdel2(:) * X(:) *                                                           & !-> metric terms
+              ( - (1.0_RP + X(:)**2) * u_(:) + X(:) * Y(:) * v_(:) ) * MOMY_(:,ke)            & !
+            - 2.0_RP * v_(:) * MOMZ_(:,ke) / R(:)                                             & !<-
+            - ( G12(:) * GradPhyd_x(:) + G22(:) * GradPhyd_y(:) ) * RGsqrtV(:)                & !-> gradient hydrostatic pressure
+            - lmesh%Gsqrt(:,ke) * (  G12(:) * ( OM2(:) * MOMZ_(:,ke) - OM3(:) * MOMY_(:,ke) ) & !-> Coriolis term
+                                   - G22(:) * ( OM1(:) * MOMZ_(:,ke) - OM3(:) * MOMX_(:,ke) ) )
+
+      !-- MOMZ
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) *   u_ (:) * MOMZ_(:,ke), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) *   v_ (:) * MOMZ_(:,ke), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( wt_(:) * MOMZ_(:,ke) + RGsqrtV(:) * DPRES_(:,ke) ), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,MOMZ_VID), LiftDelFlx)
+      
+      MOMZ_dt(:,ke) = &
+          - ( lmesh%Escale(:,ke,1,1) * Fx(:)                                                                    &
+            + lmesh%Escale(:,ke,2,2) * Fy(:)                                                                    &
+            + lmesh%Escale(:,ke,3,3) * Fz(:)                                                                    &
+            + LiftDelFlx(:) ) / lmesh%Gsqrt(:,ke)                                                               &
+          - 0.25_RP * R(:) * twoOVdel2(:)**2 * ( 1.0_RP * X(:)**2 ) * ( 1.0_RP * Y(:)**2 )                      & !-> metric terms
+            * ( - ( 1.0_RP + X(:)**2 ) * MOMX_(:,ke) * u_(:)                                                    & !
+                + 2.0_RP * X(:) * Y(:) * MOMX_(:,ke) * v_(:)                                                    & !
+                - ( 1.0_RP + Y(:)**2 ) * MOMY_(:,ke) * v_(:)  )                                                 & !<-
+          + 2.0_RP * DPRES_(:,ke) / R(:)                                                                        & !-> metric term with gradient of pressure deviaition
+          - lmesh%Gsqrt(:,ke) * ( OM1(:) * MOMY_(:,ke) - OM2(:) * MOMX_(:,ke) )                                 & !-> Coriolis term
+          - Grav * Rgam2(:) * drho(:)                                                                             !-> buoyancy term
+
+      !-- RHOT
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * u_ (:) * RHOT_(:), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * v_ (:) * RHOT_(:), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * wt_(:) * RHOT_(:), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,RHOT_VID), LiftDelFlx)
+      
+      RHOT_dt(:,ke) = &
+          - ( lmesh%Escale(:,ke,1,1) * Fx(:)      &
+            + lmesh%Escale(:,ke,2,2) * Fy(:)      &
+            + lmesh%Escale(:,ke,3,3) * Fz(:)      &
+            + LiftDelFlx(:) ) / lmesh%Gsqrt(:,ke) 
+    end do
+    !$omp end do
+    !$omp end parallel
+    call PROF_rapend('cal_dyn_tend_interior', 3)
+
+    return
+  end subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_deep_atm
+
+end module scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve_tune1.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve_tune1.F90
@@ -1,0 +1,681 @@
+!-------------------------------------------------------------------------------
+!> module FElib / Fluid dyn solver / Atmosphere / Global nonhydrostatic model / HEVE
+!!
+!! @par Description
+!!      HEVE DGM scheme for Global Atmospheric Dynamical process. 
+!!      The governing equations is a fully compressibile nonhydrostic equations, 
+!!      which consist of mass, momentum, and thermodynamics (density * potential temperature conservation) equations. 
+!!
+!! @author Team SCALE
+!<
+!-------------------------------------------------------------------------------
+#include "scaleFElib.h"
+module scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve
+  !-----------------------------------------------------------------------------
+  !
+  !++ Used modules
+  !
+  use scale_precision
+  use scale_io
+  use scale_prc
+  use scale_prof
+  use scale_const, only: &
+    GRAV => CONST_GRAV,    &
+    Rdry => CONST_Rdry,    &
+    CPdry => CONST_CPdry,  &
+    CVdry => CONST_CVdry,  &
+    PRES00 => CONST_PRE00, &
+    RPlanet => CONST_RADIUS
+
+  use scale_sparsemat  
+  use scale_element_base, only: &
+    ElementBase2D, ElementBase3D
+  use scale_element_hexahedral, only: HexahedralElement
+  use scale_localmesh_2d, only: LocalMesh2D  
+  use scale_localmesh_3d, only: LocalMesh3D
+  use scale_mesh_base2d, only: MeshBase2D
+  use scale_mesh_base3d, only: MeshBase3D
+  use scale_localmeshfield_base, only: LocalMeshField3D
+  use scale_meshfield_base, only: MeshField3D
+
+  use scale_atm_dyn_dgm_nonhydro3d_common, only: &
+    atm_dyn_dgm_nonhydro3d_common_Init,                       &
+    atm_dyn_dgm_nonhydro3d_common_Final,                      &
+    DENS_VID => PRGVAR_DDENS_ID, RHOT_VID => PRGVAR_DRHOT_ID, &
+    MOMX_VID => PRGVAR_MOMX_ID, MOMY_VID => PRGVAR_MOMY_ID,   &
+    MOMZ_VID => PRGVAR_MOMZ_ID,                               &
+    PRGVAR_NUM, IntrpMat_VPOrdM1
+  
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public procedures
+  !
+  public :: atm_dyn_dgm_globalnonhydro3d_rhot_heve_Init
+  public :: atm_dyn_dgm_globalnonhydro3d_rhot_heve_Final
+  public :: atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_shallow_atm
+  public :: atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_deep_atm
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public parameters & variables
+  !
+  
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedures & variables
+  !
+  !-------------------
+
+contains
+!OCL SERIAL
+  subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_Init( mesh )
+    implicit none
+    class(MeshBase3D), intent(in) :: mesh
+    !--------------------------------------------
+
+    call atm_dyn_dgm_nonhydro3d_common_Init( mesh )
+
+    return
+  end subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_Init
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_Final()
+    implicit none
+    !--------------------------------------------
+    
+    call atm_dyn_dgm_nonhydro3d_common_Final()    
+    return
+  end subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_Final  
+
+  !-------------------------------
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_shallow_atm( &
+    DENS_dt, MOMX_dt, MOMY_dt, MOMZ_dt, RHOT_dt,                                & ! (out)
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd, CORIOLIS,  & ! (in)
+    Rtot, CVtot, CPtot,                                                         & ! (in)
+    Dx, Dy, Dz, Sx, Sy, Sz, Lift, lmesh, elem, lmesh2D, elem2D )                  ! (in)
+
+    use scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux, only: &
+      get_ebnd_flux => atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalhvc
+    use scale_const, only: &
+      OHM => CONST_OHM
+    implicit none
+
+    class(LocalMesh3D), intent(in) :: lmesh
+    class(ElementBase3D), intent(in) :: elem
+    class(LocalMesh2D), intent(in) :: lmesh2D
+    class(ElementBase2D), intent(in) :: elem2D
+    type(SparseMat), intent(in) :: Dx, Dy, Dz, Sx, Sy, Sz, Lift
+    real(RP), intent(out) :: DENS_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMX_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMY_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMZ_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: RHOT_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DDENS_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMX_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMY_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMZ_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DRHOT_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DPRES_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DENS_hyd(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: PRES_hyd(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: CORIOLIS(elem2D%Np,lmesh2D%NeA)
+    real(RP), intent(in)  :: Rtot (elem%Np,lmesh%NeA)    
+    real(RP), intent(in)  :: CVtot(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: CPtot(elem%Np,lmesh%NeA)
+
+    ! modified by ren
+    real(RP) :: wk(elem%Np, 7)
+    real(RP) :: Fx(elem%Np, 6), Fy(elem%Np, 6), Fz(elem%Np, 7), LiftDelFlx(elem%Np, 7)
+    ! -----------------
+    real(RP) :: GradPhyd_x(elem%Np), GradPhyd_y(elem%Np)
+    real(RP) :: del_flux(elem%NfpTot,lmesh%Ne,PRGVAR_NUM)
+    real(RP) :: del_flux_hyd(elem%NfpTot,lmesh%Ne,2)
+    real(RP) :: RHOT_(elem%Np)
+    real(RP) :: rdens_(elem%Np), u_(elem%Np), v_(elem%Np), w_(elem%Np), wt_(elem%np), drho(elem%Np)
+
+    real(RP) :: G11(elem%Np), G12(elem%Np), G22(elem%Np)
+    real(RP) :: GsqrtV(elem%Np), RGsqrtV(elem%Np)
+    real(RP) :: X2D(elem2D%Np,lmesh2D%Ne), Y2D(elem2D%Np,lmesh2D%Ne)
+    real(RP) :: X(elem%Np), Y(elem%Np), twoOVdel2(elem%Np)
+    real(RP) :: CORI(elem%Np,2)
+    logical :: is_panel1to4
+    real(RP) :: s
+    real(RP) :: tmp1, tmp2, tmp3, tmp4
+
+    integer :: ke, ke2d, kp
+    integer :: p, p12, p3
+
+    real(RP) :: gamm, rgamm    
+    real(RP) :: rP0
+    real(RP) :: RovP0, P0ovR
+    !------------------------------------------------------------------------
+
+    call PROF_rapstart('cal_dyn_tend_bndflux', 3)
+    call get_ebnd_flux( &
+      del_flux, del_flux_hyd,                                                  & ! (out)
+      DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd,         & ! (in)
+      Rtot, CVtot, CPtot,                                                      & ! (in)
+      lmesh%Gsqrt, lmesh%GIJ(:,:,1,1), lmesh%GIJ(:,:,1,2), lmesh%GIJ(:,:,2,2), & ! (in)
+      lmesh%GsqrtH, lmesh%gam, lmesh%GI3(:,:,1), lmesh%GI3(:,:,2),             & ! (in)    
+      lmesh%normal_fn(:,:,1), lmesh%normal_fn(:,:,2), lmesh%normal_fn(:,:,3),  & ! (in)
+      lmesh%vmapM, lmesh%vmapP, elem%IndexH2Dto3D_bnd,                         & ! (in)
+      lmesh, elem, lmesh2D, elem2D                                             ) ! (in)
+    call PROF_rapend('cal_dyn_tend_bndflux', 3)
+ 
+    !-----
+    call PROF_rapstart('cal_dyn_tend_interior', 3)
+    gamm  = CPDry / CvDry
+    rgamm = CvDry / CpDry
+    rP0   = 1.0_RP / PRES00
+    RovP0 = Rdry * rP0
+    P0ovR = PRES00 / Rdry
+
+    s = 1.0_RP 
+    is_panel1to4 = .true.
+    if ( lmesh%panelID == 5 ) then
+      is_panel1to4 = .false.
+    else if ( lmesh%panelID == 6 ) then
+      is_panel1to4 = .false.
+      s = - 1.0_RP
+    end if
+
+    !$omp parallel private(                        &
+    !$omp RHOT_, rdens_, u_, v_, w_, wt_,          &
+    !$omp Fx, Fy, Fz, LiftDelFlx,                  &
+    !$omp drho, GradPhyd_x, GradPhyd_y,            &
+    !$omp G11, G12, G22, GsqrtV, RGsqrtV,          &
+    !$omp X, Y, twoOVdel2,                         &
+    !$omp CORI, ke, ke2D, wk, kp, tmp1, tmp2, tmp3, tmp4 )
+
+    !$omp do 
+    do ke2D = lmesh2D%NeS, lmesh2D%NeE
+      do kp=1, elem2D%Np
+        X2D(kp,ke2d) = tan(lmesh2D%pos_en(kp,ke2d,1))
+        Y2D(kp,ke2d) = tan(lmesh2D%pos_en(kp,ke2d,2))
+      end do
+    end do
+
+    !$omp do
+    do ke = lmesh%NeS, lmesh%NeE
+      !--
+      ke2d = lmesh%EMap3Dto2D(ke)
+      do kp=1, elem%Np
+        G11(kp) = lmesh%GIJ(elem%IndexH2Dto3D(kp),ke2d,1,1)
+        G12(kp) = lmesh%GIJ(elem%IndexH2Dto3D(kp),ke2d,1,2)
+        G22(kp) = lmesh%GIJ(elem%IndexH2Dto3D(kp),ke2d,2,2)
+      enddo
+      do kp=1, elem%Np
+        GsqrtV(kp)  = lmesh%Gsqrt(kp,ke) / lmesh%GsqrtH(elem%IndexH2Dto3D(kp),ke2d)
+      enddo
+      do kp=1, elem%Np
+        RGsqrtV(kp) = 1.0_RP / GsqrtV(kp)
+      enddo
+
+      !--
+      do kp=1, elem%Np
+        RHOT_(kp) = P0ovR * ( PRES_hyd(kp,ke) * rP0 )**rgamm + DRHOT_(kp,ke)
+      enddo
+      ! DPRES_(:) = PRES00 * ( Rtot(:,ke) * rP0 * RHOT_(:) )**( CPtot(:,ke) / CVtot(:,ke) ) &
+      !           - PRES_hyd(:,ke)
+
+      do kp=1, elem%Np
+        rdens_(kp) = 1.0_RP / ( DDENS_(kp,ke) + DENS_hyd(kp,ke) )
+      enddo
+      do kp=1, elem%Np
+        u_ (kp) = MOMX_(kp,ke) * rdens_(kp)
+        v_ (kp) = MOMY_(kp,ke) * rdens_(kp)
+        w_ (kp) = MOMZ_(kp,ke) * rdens_(kp)
+      enddo
+      do kp=1, elem%Np
+        wt_(kp) = w_(kp) * RGsqrtV(kp) + lmesh%GI3(kp,ke,1) * u_(kp) + lmesh%GI3(kp,ke,2) * v_(kp) 
+      enddo
+
+
+      !-- Fx:
+      !-- 1 Gradient hydrostatic pressure
+      !-- 2 DENS
+      !-- 3 MOMX
+      !-- 4 MOMY
+      !-- 5 MOMZ
+      !-- 6 RHOT
+      do kp=1, elem%Np
+        wk(kp, 1) = GsqrtV(kp) * PRES_hyd(kp,ke)
+      enddo
+      do kp=1, elem%Np
+        tmp1 = lmesh%Gsqrt(kp,ke) *   u_ (kp)
+        tmp2 = lmesh%Gsqrt(kp,ke) *   DPRES_(kp, ke)
+
+        wk(kp, 2) = lmesh%Gsqrt(kp,ke) * MOMX_(kp,ke)
+        wk(kp, 3) = tmp1 * MOMX_(kp,ke) + tmp2 * G11(kp)
+        wk(kp, 4) = tmp1 * MOMY_(kp,ke) + tmp2 * G12(kp)
+        wk(kp, 5) = tmp1 * MOMZ_(kp,ke)
+        wk(kp, 6) = tmp1 * RHOT_(kp)
+      enddo
+      !-- calculate
+      call sparsemat_matmul(Dx, wk, Fx, 6)
+
+      !-- Fy:
+      !-- 1 Gradient hydrostatic pressure
+      !-- 2 DENS
+      !-- 3 MOMX
+      !-- 4 MOMY
+      !-- 5 MOMZ
+      !-- 6 RHOT
+      ! wk(:, 1) = GsqrtV(:) * PRES_hyd(:,ke)
+      do kp=1, elem%Np
+        tmp1 = lmesh%Gsqrt(kp,ke) *   v_ (kp)
+        tmp2 = lmesh%Gsqrt(kp,ke) *   DPRES_(kp, ke)
+
+        wk(kp, 2) = lmesh%Gsqrt(kp,ke) * MOMY_(kp,ke)
+        wk(kp, 3) = tmp1 * MOMX_(kp,ke) + tmp2 * G12(kp)
+        wk(kp, 4) = tmp1 * MOMY_(kp,ke) + tmp2 * G22(kp)
+        wk(kp, 5) = tmp1 * MOMZ_(kp,ke)
+        wk(kp, 6) = tmp1 * RHOT_(kp)
+      enddo
+      !-- calculate
+      call sparsemat_matmul(Dy, wk, Fy, 6)
+
+      !-- Fz:
+      !-- 1 Gradient hydrostatic pressure
+      !-- 2 Gradient hydrostatic pressure
+      !-- 3 DENS
+      !-- 4 MOMX
+      !-- 5 MOMY
+      !-- 6 MOMZ
+      !-- 7 RHOT
+      do kp=1, elem%Np
+        tmp1 = wk(kp, 1)
+        wk(kp, 1) = tmp1 * lmesh%GI3(kp,ke,1)
+        wk(kp, 2) = tmp1 * lmesh%GI3(kp,ke,2)
+      enddo
+      do kp=1, elem%Np
+        tmp1 = lmesh%Gsqrt(kp,ke) * wt_(kp)
+        tmp2 = lmesh%Gsqrt(kp,ke) * DPRES_(kp,ke)
+
+        wk(kp, 3) = tmp1 * ( DDENS_(kp,ke) + DENS_hyd(kp,ke) )     
+        wk(kp, 4) = tmp1 * MOMX_(kp,ke) + tmp2 * ( lmesh%GI3(kp,ke,1) * G11(kp) + lmesh%GI3(kp,ke,2) * G12(kp) )
+        wk(kp, 5) = tmp1 * MOMY_(kp,ke) + tmp2 * ( lmesh%GI3(kp,ke,1) * G12(kp) + lmesh%GI3(kp,ke,2) * G22(kp) ) 
+        wk(kp, 6) = tmp1 * MOMZ_(kp,ke) + tmp2 * RGsqrtV(kp)
+        wk(kp, 7) = tmp1 * RHOT_(kp)
+      enddo
+      !-- calculate
+      call sparsemat_matmul(Dz, wk, Fz, 7, 7)
+
+      !-- LiftDelFlx:
+      !-- 1 Gradient hydrostatic pressure
+      !-- 2 Gradient hydrostatic pressure
+      !-- 3 DENS
+      !-- 4 RHOT
+      !-- 5 MOMZ
+      !-- 6 MOMX
+      !-- 7 MOMY
+      do kp=1, elem%Np
+        wk(kp, 1) = lmesh%Fscale(kp,ke) * del_flux_hyd(kp,ke,1)
+        wk(kp, 2) = lmesh%Fscale(kp,ke) * del_flux_hyd(kp,ke,2)
+      enddo
+      do kp=1, elem%Np
+        ! wk(kp, 3) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,DENS_VID)
+        ! wk(kp, 4) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,MOMX_VID)
+        ! wk(kp, 5) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,MOMY_VID)
+        ! wk(kp, 6) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,MOMZ_VID)
+        ! wk(kp, 7) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,RHOT_VID)
+        wk(kp, 3) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,DENS_VID)
+        wk(kp, 4) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,RHOT_VID)
+      enddo
+      do kp=1, elem%Np
+        wk(kp, 5) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,MOMZ_VID)
+        wk(kp, 6) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,MOMX_VID)
+        wk(kp, 7) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,MOMY_VID)
+      enddo
+      !-- calculate
+      call sparsemat_matmul(Lift, wk, LiftDelFlx, 7, 7)
+      
+      do kp=1, elem%Np
+        X(kp) = X2D(elem%IndexH2Dto3D(kp),ke2d)
+        Y(kp) = Y2D(elem%IndexH2Dto3D(kp),ke2d)
+      enddo
+
+      do kp=1, elem%Np
+        twoOVdel2(kp) = 2.0_RP / ( 1.0_RP + X(kp)**2 + Y(kp)**2 )
+      enddo
+
+      do kp=1, elem%Np
+        CORI(kp,1) = s * OHM * twoOVdel2(kp) * ( - X(kp) * Y(kp)          * MOMX_(kp,ke) + ( 1.0_RP + X(kp)**2 ) * MOMY_(kp,ke) )
+        CORI(kp,2) = s * OHM * twoOVdel2(kp) * ( - ( 1.0_RP + Y(kp)**2 ) * MOMX_(kp,ke) +  X(kp) * Y(kp)         * MOMY_(kp,ke) )
+      enddo
+      if ( is_panel1to4 ) then
+        do kp=1, elem%Np
+          CORI(kp,1) = s * Y(kp) * CORI(kp,1)
+          CORI(kp,2) = s * Y(kp) * CORI(kp,2)
+        enddo
+      end if
+
+      drho(:) = matmul(IntrpMat_VPOrdM1, DDENS_(:,ke))
+
+      !-- Gradient hydrostatic pressure
+      do kp=1, elem%Np
+        GradPhyd_x(kp) = lmesh%Escale(kp,ke,1,1) * Fx(kp,1) &
+                      + lmesh%Escale(kp,ke,3,3) * Fz(kp,1) &
+                      + LiftDelFlx(kp,1)
+
+        GradPhyd_y(kp) = lmesh%Escale(kp,ke,2,2) * Fy(kp,1) &
+                      + lmesh%Escale(kp,ke,3,3) * Fz(kp,2) &
+                      + LiftDelFlx(kp,2)
+      enddo
+      
+      !-- DENS
+      do kp = 1, elem%Np
+        DENS_dt(kp,ke) = - ( &
+              lmesh%Escale(kp,ke,1,1) * Fx(kp,2)     &
+            + lmesh%Escale(kp,ke,2,2) * Fy(kp,2)     &
+            + lmesh%Escale(kp,ke,3,3) * Fz(kp,3)     &
+            + LiftDelFlx(kp,3) ) / lmesh%Gsqrt(kp,ke)
+      enddo
+      
+      !-- MOMX
+      do kp=1, elem%Np
+        MOMX_dt(kp,ke) = &
+            - ( lmesh%Escale(kp,ke,1,1) * Fx(kp,3)                                         &
+              + lmesh%Escale(kp,ke,2,2) * Fy(kp,3)                                         &
+              + lmesh%Escale(kp,ke,3,3) * Fz(kp,4)                                         &
+              + LiftDelFlx(kp,6)                   ) / lmesh%Gsqrt(kp,ke)                  &
+            - twoOVdel2(kp) * Y(kp) *                                                    &
+              ( X(kp) * Y(kp) * u_(kp) - (1.0_RP + Y(kp)**2) * v_(kp) ) * MOMX_(kp,ke)       &
+            - ( G11(kp) * GradPhyd_x(kp) + G12(kp) * GradPhyd_y(kp) ) * RGsqrtV(kp)         &
+            + CORI(kp,1)              
+      enddo
+
+      !-- MOMY
+      do kp=1, elem%Np
+        MOMY_dt(kp,ke) = &
+              - ( lmesh%Escale(kp,ke,1,1) * Fx(kp,4)                                         &
+                + lmesh%Escale(kp,ke,2,2) * Fy(kp,4)                                         &
+                + lmesh%Escale(kp,ke,3,3) * Fz(kp,5)                                         &
+                + LiftDelFlx(kp,7)                  ) / lmesh%Gsqrt(kp,ke)                   &
+              - twoOVdel2(kp) * X(kp) *                                                    &
+                ( - (1.0_RP + X(kp)**2) * u_(kp) + X(kp) * Y(kp) * v_(kp) ) * MOMY_(kp,ke)     &
+              - ( G12(kp) * GradPhyd_x(kp) + G22(kp) * GradPhyd_y(kp) ) * RGsqrtV(kp)         &
+              + CORI(kp,2) 
+      enddo
+
+      !-- MOMZ
+      do kp=1, elem%Np
+        MOMZ_dt(kp,ke) = &
+            - ( lmesh%Escale(kp,ke,1,1) * Fx(kp,5)       &
+              + lmesh%Escale(kp,ke,2,2) * Fy(kp,5)       &
+              + lmesh%Escale(kp,ke,3,3) * Fz(kp,6)       &
+              + LiftDelFlx(kp,5) ) / lmesh%Gsqrt(kp,ke)  &
+            - Grav * drho(kp)
+      enddo
+
+      !-- RHOT
+      do kp=1, elem%Np
+        RHOT_dt(kp,ke) = &
+            - ( lmesh%Escale(kp,ke,1,1) * Fx(kp,6)      &
+              + lmesh%Escale(kp,ke,2,2) * Fy(kp,6)      &
+              + lmesh%Escale(kp,ke,3,3) * Fz(kp,7)      &
+              + LiftDelFlx(kp,4) ) / lmesh%Gsqrt(kp,ke) 
+      enddo
+    
+    end do
+    !$omp end do
+    !$omp end parallel
+    call PROF_rapend('cal_dyn_tend_interior', 3)
+
+    return
+  end subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_shallow_atm
+
+
+!OCL SERIAL
+subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_deep_atm( &
+    DENS_dt, MOMX_dt, MOMY_dt, MOMZ_dt, RHOT_dt,                                & ! (out)
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd, CORIOLIS,  & ! (in)
+    Rtot, CVtot, CPtot,                                                         & ! (in)
+    Dx, Dy, Dz, Sx, Sy, Sz, Lift, lmesh, elem, lmesh2D, elem2D )                  ! (in)
+
+    use scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux, only: &
+      get_ebnd_flux => atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalhvc
+    use scale_const, only: &
+      OHM => CONST_OHM
+    implicit none
+
+    class(LocalMesh3D), intent(in) :: lmesh
+    class(ElementBase3D), intent(in) :: elem
+    class(LocalMesh2D), intent(in) :: lmesh2D
+    class(ElementBase2D), intent(in) :: elem2D
+    type(SparseMat), intent(in) :: Dx, Dy, Dz, Sx, Sy, Sz, Lift
+    real(RP), intent(out) :: DENS_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMX_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMY_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMZ_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: RHOT_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DDENS_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMX_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMY_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMZ_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DRHOT_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DPRES_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DENS_hyd(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: PRES_hyd(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: CORIOLIS(elem2D%Np,lmesh2D%NeA)
+    real(RP), intent(in)  :: Rtot (elem%Np,lmesh%NeA)    
+    real(RP), intent(in)  :: CVtot(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: CPtot(elem%Np,lmesh%NeA)
+
+    real(RP) :: Fx(elem%Np), Fy(elem%Np), Fz(elem%Np), LiftDelFlx(elem%Np)
+    real(RP) :: GradPhyd_x(elem%Np), GradPhyd_y(elem%Np)
+    real(RP) :: del_flux(elem%NfpTot,lmesh%Ne,PRGVAR_NUM)
+    real(RP) :: del_flux_hyd(elem%NfpTot,lmesh%Ne,2)
+    real(RP) :: RHOT_(elem%Np)
+    real(RP) :: rdens_(elem%Np), u_(elem%Np), v_(elem%Np), w_(elem%Np), wt_(elem%np), drho(elem%Np)
+
+    real(RP) :: G11(elem%Np), G12(elem%Np), G22(elem%Np)
+    real(RP) :: GsqrtV(elem%Np), RGsqrtV(elem%Np), Rgam2(elem%Np)
+    real(RP) :: X2D(elem2D%Np,lmesh2D%Ne), Y2D(elem2D%Np,lmesh2D%Ne)
+    real(RP) :: X(elem%Np), Y(elem%Np), twoOVdel2(elem%Np)
+    real(RP) :: OM1(elem%Np), OM2(elem%Np), OM3(elem%Np), DEL(elem%Np), R(elem%Np)
+    logical :: is_panel1to4
+    real(RP) :: s
+
+    integer :: ke, ke2d
+    integer :: p
+    
+    real(RP) :: rgamm    
+    real(RP) :: rP0
+    real(RP) :: P0ovR
+    !------------------------------------------------------------------------
+
+    call PROF_rapstart('cal_dyn_tend_bndflux', 3)
+    call get_ebnd_flux( &
+      del_flux, del_flux_hyd,                                                  & ! (out)
+      DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd,         & ! (in)
+      Rtot, CVtot, CPtot,                                                      & ! (in)
+      lmesh%Gsqrt, lmesh%GIJ(:,:,1,1), lmesh%GIJ(:,:,1,2), lmesh%GIJ(:,:,2,2), & ! (in)
+      lmesh%GsqrtH, lmesh%gam, lmesh%GI3(:,:,1), lmesh%GI3(:,:,2),             & ! (in)    
+      lmesh%normal_fn(:,:,1), lmesh%normal_fn(:,:,2), lmesh%normal_fn(:,:,3),  & ! (in)
+      lmesh%vmapM, lmesh%vmapP, elem%IndexH2Dto3D_bnd,                         & ! (in)
+      lmesh, elem, lmesh2D, elem2D                                             ) ! (in)
+    call PROF_rapend('cal_dyn_tend_bndflux', 3)
+ 
+    !-----
+    call PROF_rapstart('cal_dyn_tend_interior', 3)
+    rgamm = CvDry / CpDry
+    rP0   = 1.0_RP / PRES00
+    P0ovR = PRES00 / Rdry
+
+    s = 2.0_RP * OHM
+    is_panel1to4 = .true.
+    if ( lmesh%panelID == 5 ) then
+      is_panel1to4 = .false.
+    else if ( lmesh%panelID == 6 ) then
+      is_panel1to4 = .false.
+      s = - s
+    end if
+
+    !$omp parallel private(                        &
+    !$omp RHOT_, rdens_, u_, v_, w_, wt_,          &
+    !$omp Fx, Fy, Fz, LiftDelFlx,                  &
+    !$omp drho, GradPhyd_x, GradPhyd_y,            &
+    !$omp G11, G12, G22, Rgam2, GsqrtV, RGsqrtV,   &
+    !$omp X, Y, twoOVdel2,                         &
+    !$omp OM1, OM2, OM3, DEL, R, ke, ke2D          )
+
+    !$omp do
+    do ke2D = lmesh2D%NeS, lmesh2D%NeE
+      X2D(:,ke2d) = tan(lmesh2D%pos_en(:,ke2d,1))
+      Y2D(:,ke2d) = tan(lmesh2D%pos_en(:,ke2d,2))
+    end do
+
+    !$omp do
+    do ke = lmesh%NeS, lmesh%NeE
+      !--
+      ke2d = lmesh%EMap3Dto2D(ke)
+      Rgam2(:) = 1.0_RP / lmesh%gam(:,ke)**2
+      G11(:) = lmesh%GIJ(elem%IndexH2Dto3D,ke2d,1,1) * Rgam2(:)
+      G12(:) = lmesh%GIJ(elem%IndexH2Dto3D,ke2d,1,2) * Rgam2(:)
+      G22(:) = lmesh%GIJ(elem%IndexH2Dto3D,ke2d,2,2) * Rgam2(:)
+      GsqrtV(:)  = lmesh%Gsqrt(:,ke) * Rgam2(:) / lmesh%GsqrtH(elem%IndexH2Dto3D,ke2d)
+      RGsqrtV(:) = 1.0_RP / GsqrtV(:)
+
+      !--
+      RHOT_(:) = P0ovR * ( PRES_hyd(:,ke) * rP0 )**rgamm + DRHOT_(:,ke)
+      ! DPRES_(:) = PRES00 * ( Rtot(:,ke) * rP0 * RHOT_(:) )**( CPtot(:,ke) / CVtot(:,ke) ) &
+      !           - PRES_hyd(:,ke)
+
+      rdens_(:) = 1.0_RP / ( DDENS_(:,ke) + DENS_hyd(:,ke) )
+      u_ (:) = MOMX_(:,ke) * rdens_(:)
+      v_ (:) = MOMY_(:,ke) * rdens_(:)
+      w_ (:) = MOMZ_(:,ke) * rdens_(:)
+      wt_(:) = w_(:) * RGsqrtV(:) + lmesh%GI3(:,ke,1) * u_(:) + lmesh%GI3(:,ke,2) * v_(:) 
+
+      X(:) = X2D(elem%IndexH2Dto3D,ke2d)
+      Y(:) = Y2D(elem%IndexH2Dto3D,ke2d)
+      DEL(:) = sqrt( 1.0_RP + X(:)**2 + Y(:)**2 )
+      twoOVdel2(:) = 2.0_RP / ( 1.0_RP + X(:)**2 + Y(:)**2 )
+
+      R(:) = RPlanet * lmesh%gam(:,ke)
+
+      !-  pnl=1~4: OM1:                     0, OM2: s del / (r (1+Y^2)) ,   s OM3 : Y /del
+      !-  pnl=5,6: OM1: - s X del/(r (1+X^2)), OM2: -  s Y del/(r(1+Y^2)), OM3 : s/del
+      if ( is_panel1to4 ) then
+        OM1(:) = 0.0_RP
+        OM2(:) = s * DEL(:) / ( R(:) * ( 1.0_RP + Y(:)**2 ) )
+        OM3(:) = s * Y(:) / DEL(:)
+      else
+        OM1(:) = - s * X(:) * DEL(:) / ( R(:) * ( 1.0_RP + X(:)**2 ) )
+        OM2(:) = - s * Y(:) * DEL(:) / ( R(:) * ( 1.0_RP + Y(:)**2 ) )
+        OM3(:) =   s / DEL(:)
+      end if
+
+      drho(:) = matmul(IntrpMat_VPOrdM1, DDENS_(:,ke))
+
+      !-- Gradient hydrostatic pressure
+      
+      call sparsemat_matmul(Dx, GsqrtV(:) * PRES_hyd(:,ke), Fx)
+      call sparsemat_matmul(Dz, GsqrtV(:) * lmesh%GI3(:,ke,1) * PRES_hyd(:,ke), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux_hyd(:,ke,1), LiftDelFlx)
+      GradPhyd_x(:) = lmesh%Escale(:,ke,1,1) * Fx(:) &
+                    + lmesh%Escale(:,ke,3,3) * Fz(:) &
+                    + LiftDelFlx(:)
+
+      call sparsemat_matmul(Dy, GsqrtV(:) * PRES_hyd(:,ke), Fy)
+      call sparsemat_matmul(Dz, GsqrtV(:) * lmesh%GI3(:,ke,2) * PRES_hyd(:,ke), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux_hyd(:,ke,2), LiftDelFlx)
+      GradPhyd_y(:) = lmesh%Escale(:,ke,2,2) * Fy(:) &
+                    + lmesh%Escale(:,ke,3,3) * Fz(:) &
+                    + LiftDelFlx(:)
+      
+      !-- DENS
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * MOMX_(:,ke), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * MOMY_(:,ke), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( DDENS_(:,ke) + DENS_hyd(:,ke) ) * wt_(:), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,DENS_VID), LiftDelFlx)
+
+      DENS_dt(:,ke) = - ( &
+            lmesh%Escale(:,ke,1,1) * Fx(:)     &
+          + lmesh%Escale(:,ke,2,2) * Fy(:)     &
+          + lmesh%Escale(:,ke,3,3) * Fz(:)     &
+          + LiftDelFlx(:) ) / lmesh%Gsqrt(:,ke)
+      
+      !-- MOMX
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * ( u_ (:) * MOMX_(:,ke) + G11(:) * DPRES_(:,ke) ), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * ( v_ (:) * MOMX_(:,ke) + G12(:) * DPRES_(:,ke) ), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( wt_(:) * MOMX_(:,ke)                              &
+                                                    + ( lmesh%GI3(:,ke,1) * G11(:) + lmesh%GI3(:,ke,2) * G12(:) ) * DPRES_(:,ke) ), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,MOMX_VID), LiftDelFlx)
+
+      MOMX_dt(:,ke) = &
+          - ( lmesh%Escale(:,ke,1,1) * Fx(:)                                                &
+            + lmesh%Escale(:,ke,2,2) * Fy(:)                                                &
+            + lmesh%Escale(:,ke,3,3) * Fz(:)                                                &
+            + LiftDelFlx(:)                   ) / lmesh%Gsqrt(:,ke)                         &
+          - twoOVdel2(:) * Y(:) *                                                           & !-> metric terms
+            ( X(:) * Y(:) * u_(:) - ( 1.0_RP + Y(:)**2 ) * v_(:) ) * MOMX_(:,ke)            & !
+          - 2.0_RP * u_(:) * MOMZ_(:,ke) / R(:)                                             & !<-
+          - ( G11(:) * GradPhyd_x(:) + G12(:) * GradPhyd_y(:) ) * RGsqrtV(:)                & !-> gradient hydrostatic pressure
+          - lmesh%Gsqrt(:,ke) * (  G11(:) * ( OM2(:) * MOMZ_(:,ke) - OM3(:) * MOMY_(:,ke) ) & !-> Coriolis term
+                                 - G12(:) * ( OM1(:) * MOMZ_(:,ke) - OM3(:) * MOMX_(:,ke) ) )
+
+      !-- MOMY
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * ( u_ (:) * MOMY_(:,ke) + G12(:) * DPRES_(:,ke) ), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * ( v_ (:) * MOMY_(:,ke) + G22(:) * DPRES_(:,ke) ), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( wt_(:) * MOMY_(:,ke)                              &
+                                                    + ( lmesh%GI3(:,ke,1) * G12(:) + lmesh%GI3(:,ke,2) * G22(:) ) * DPRES_(:,ke) ), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,MOMY_VID), LiftDelFlx)
+
+      MOMY_dt(:,ke) = &
+            - ( lmesh%Escale(:,ke,1,1) * Fx(:)                                                &
+              + lmesh%Escale(:,ke,2,2) * Fy(:)                                                &
+              + lmesh%Escale(:,ke,3,3) * Fz(:)                                                &
+              + LiftDelFlx(:)                  ) / lmesh%Gsqrt(:,ke)                          &
+            - twoOVdel2(:) * X(:) *                                                           & !-> metric terms
+              ( - (1.0_RP + X(:)**2) * u_(:) + X(:) * Y(:) * v_(:) ) * MOMY_(:,ke)            & !
+            - 2.0_RP * v_(:) * MOMZ_(:,ke) / R(:)                                             & !<-
+            - ( G12(:) * GradPhyd_x(:) + G22(:) * GradPhyd_y(:) ) * RGsqrtV(:)                & !-> gradient hydrostatic pressure
+            - lmesh%Gsqrt(:,ke) * (  G12(:) * ( OM2(:) * MOMZ_(:,ke) - OM3(:) * MOMY_(:,ke) ) & !-> Coriolis term
+                                   - G22(:) * ( OM1(:) * MOMZ_(:,ke) - OM3(:) * MOMX_(:,ke) ) )
+
+      !-- MOMZ
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) *   u_ (:) * MOMZ_(:,ke), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) *   v_ (:) * MOMZ_(:,ke), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( wt_(:) * MOMZ_(:,ke) + RGsqrtV(:) * DPRES_(:,ke) ), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,MOMZ_VID), LiftDelFlx)
+      
+      MOMZ_dt(:,ke) = &
+          - ( lmesh%Escale(:,ke,1,1) * Fx(:)                                                                    &
+            + lmesh%Escale(:,ke,2,2) * Fy(:)                                                                    &
+            + lmesh%Escale(:,ke,3,3) * Fz(:)                                                                    &
+            + LiftDelFlx(:) ) / lmesh%Gsqrt(:,ke)                                                               &
+          - 0.25_RP * R(:) * twoOVdel2(:)**2 * ( 1.0_RP * X(:)**2 ) * ( 1.0_RP * Y(:)**2 )                      & !-> metric terms
+            * ( - ( 1.0_RP + X(:)**2 ) * MOMX_(:,ke) * u_(:)                                                    & !
+                + 2.0_RP * X(:) * Y(:) * MOMX_(:,ke) * v_(:)                                                    & !
+                - ( 1.0_RP + Y(:)**2 ) * MOMY_(:,ke) * v_(:)  )                                                 & !<-
+          + 2.0_RP * DPRES_(:,ke) / R(:)                                                                        & !-> metric term with gradient of pressure deviaition
+          - lmesh%Gsqrt(:,ke) * ( OM1(:) * MOMY_(:,ke) - OM2(:) * MOMX_(:,ke) )                                 & !-> Coriolis term
+          - Grav * Rgam2(:) * drho(:)                                                                             !-> buoyancy term
+
+      !-- RHOT
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * u_ (:) * RHOT_(:), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * v_ (:) * RHOT_(:), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * wt_(:) * RHOT_(:), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,RHOT_VID), LiftDelFlx)
+      
+      RHOT_dt(:,ke) = &
+          - ( lmesh%Escale(:,ke,1,1) * Fx(:)      &
+            + lmesh%Escale(:,ke,2,2) * Fy(:)      &
+            + lmesh%Escale(:,ke,3,3) * Fz(:)      &
+            + LiftDelFlx(:) ) / lmesh%Gsqrt(:,ke) 
+    end do
+    !$omp end do
+    !$omp end parallel
+    call PROF_rapend('cal_dyn_tend_interior', 3)
+
+    return
+  end subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_deep_atm
+
+end module scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve_tune2.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve_tune2.F90
@@ -1,0 +1,673 @@
+!-------------------------------------------------------------------------------
+!> module FElib / Fluid dyn solver / Atmosphere / Global nonhydrostatic model / HEVE
+!!
+!! @par Description
+!!      HEVE DGM scheme for Global Atmospheric Dynamical process. 
+!!      The governing equations is a fully compressibile nonhydrostic equations, 
+!!      which consist of mass, momentum, and thermodynamics (density * potential temperature conservation) equations. 
+!!
+!! @author Team SCALE
+!<
+!-------------------------------------------------------------------------------
+#include "scaleFElib.h"
+module scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve
+  !-----------------------------------------------------------------------------
+  !
+  !++ Used modules
+  !
+  use scale_precision
+  use scale_io
+  use scale_prc
+  use scale_prof
+  use scale_const, only: &
+    GRAV => CONST_GRAV,    &
+    Rdry => CONST_Rdry,    &
+    CPdry => CONST_CPdry,  &
+    CVdry => CONST_CVdry,  &
+    PRES00 => CONST_PRE00, &
+    RPlanet => CONST_RADIUS
+
+  use scale_sparsemat  
+  use scale_element_base, only: &
+    ElementBase2D, ElementBase3D
+  use scale_element_hexahedral, only: HexahedralElement
+  use scale_localmesh_2d, only: LocalMesh2D  
+  use scale_localmesh_3d, only: LocalMesh3D
+  use scale_mesh_base2d, only: MeshBase2D
+  use scale_mesh_base3d, only: MeshBase3D
+  use scale_localmeshfield_base, only: LocalMeshField3D
+  use scale_meshfield_base, only: MeshField3D
+
+  use scale_atm_dyn_dgm_nonhydro3d_common, only: &
+    atm_dyn_dgm_nonhydro3d_common_Init,                       &
+    atm_dyn_dgm_nonhydro3d_common_Final,                      &
+    DENS_VID => PRGVAR_DDENS_ID, RHOT_VID => PRGVAR_DRHOT_ID, &
+    MOMX_VID => PRGVAR_MOMX_ID, MOMY_VID => PRGVAR_MOMY_ID,   &
+    MOMZ_VID => PRGVAR_MOMZ_ID,                               &
+    PRGVAR_NUM, IntrpMat_VPOrdM1
+  
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public procedures
+  !
+  public :: atm_dyn_dgm_globalnonhydro3d_rhot_heve_Init
+  public :: atm_dyn_dgm_globalnonhydro3d_rhot_heve_Final
+  public :: atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_shallow_atm
+  public :: atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_deep_atm
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public parameters & variables
+  !
+  
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedures & variables
+  !
+  !-------------------
+
+contains
+!OCL SERIAL
+  subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_Init( mesh )
+    implicit none
+    class(MeshBase3D), intent(in) :: mesh
+    !--------------------------------------------
+
+    call atm_dyn_dgm_nonhydro3d_common_Init( mesh )
+
+    return
+  end subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_Init
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_Final()
+    implicit none
+    !--------------------------------------------
+    
+    call atm_dyn_dgm_nonhydro3d_common_Final()    
+    return
+  end subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_Final  
+
+  !-------------------------------
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_shallow_atm( &
+    DENS_dt, MOMX_dt, MOMY_dt, MOMZ_dt, RHOT_dt,                                & ! (out)
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd, CORIOLIS,  & ! (in)
+    Rtot, CVtot, CPtot,                                                         & ! (in)
+    Dx, Dy, Dz, Sx, Sy, Sz, Lift, lmesh, elem, lmesh2D, elem2D )                  ! (in)
+
+    use scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux, only: &
+      get_ebnd_flux => atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalhvc
+    use scale_const, only: &
+      OHM => CONST_OHM
+    implicit none
+
+    class(LocalMesh3D), intent(in) :: lmesh
+    class(ElementBase3D), intent(in) :: elem
+    class(LocalMesh2D), intent(in) :: lmesh2D
+    class(ElementBase2D), intent(in) :: elem2D
+    type(SparseMat), intent(in) :: Dx, Dy, Dz, Sx, Sy, Sz, Lift
+    real(RP), intent(out) :: DENS_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMX_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMY_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMZ_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: RHOT_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DDENS_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMX_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMY_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMZ_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DRHOT_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DPRES_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DENS_hyd(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: PRES_hyd(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: CORIOLIS(elem2D%Np,lmesh2D%NeA)
+    real(RP), intent(in)  :: Rtot (elem%Np,lmesh%NeA)    
+    real(RP), intent(in)  :: CVtot(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: CPtot(elem%Np,lmesh%NeA)
+
+    ! modified by ren
+    real(RP) :: wk(7, elem%Np)
+    real(RP) :: Fx(elem%Np, 6), Fy(elem%Np, 6), Fz(elem%Np, 7), LiftDelFlx(elem%Np, 7)
+    ! -----------------
+    real(RP) :: GradPhyd_x(elem%Np), GradPhyd_y(elem%Np)
+    real(RP) :: del_flux(elem%NfpTot,lmesh%Ne,PRGVAR_NUM)
+    real(RP) :: del_flux_hyd(elem%NfpTot,lmesh%Ne,2)
+    real(RP) :: RHOT_(elem%Np)
+    real(RP) :: rdens_(elem%Np), u_(elem%Np), v_(elem%Np), w_(elem%Np), wt_(elem%np), drho(elem%Np)
+
+    real(RP) :: G11(elem%Np), G12(elem%Np), G22(elem%Np)
+    real(RP) :: GsqrtV(elem%Np), RGsqrtV(elem%Np)
+    real(RP) :: X2D(elem2D%Np,lmesh2D%Ne), Y2D(elem2D%Np,lmesh2D%Ne)
+    real(RP) :: X(elem%Np), Y(elem%Np), twoOVdel2(elem%Np)
+    real(RP) :: CORI(elem%Np,2)
+    logical :: is_panel1to4
+    real(RP) :: s
+    real(RP) :: tmp1, tmp2
+
+    integer :: ke, ke2d, kp
+    integer :: p, p12, p3
+
+    real(RP) :: gamm, rgamm    
+    real(RP) :: rP0
+    real(RP) :: RovP0, P0ovR
+    !------------------------------------------------------------------------
+
+    call PROF_rapstart('cal_dyn_tend_bndflux', 3)
+    call get_ebnd_flux( &
+      del_flux, del_flux_hyd,                                                  & ! (out)
+      DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd,         & ! (in)
+      Rtot, CVtot, CPtot,                                                      & ! (in)
+      lmesh%Gsqrt, lmesh%GIJ(:,:,1,1), lmesh%GIJ(:,:,1,2), lmesh%GIJ(:,:,2,2), & ! (in)
+      lmesh%GsqrtH, lmesh%gam, lmesh%GI3(:,:,1), lmesh%GI3(:,:,2),             & ! (in)    
+      lmesh%normal_fn(:,:,1), lmesh%normal_fn(:,:,2), lmesh%normal_fn(:,:,3),  & ! (in)
+      lmesh%vmapM, lmesh%vmapP, elem%IndexH2Dto3D_bnd,                         & ! (in)
+      lmesh, elem, lmesh2D, elem2D                                             ) ! (in)
+    call PROF_rapend('cal_dyn_tend_bndflux', 3)
+ 
+    !-----
+    call PROF_rapstart('cal_dyn_tend_interior', 3)
+    gamm  = CPDry / CvDry
+    rgamm = CvDry / CpDry
+    rP0   = 1.0_RP / PRES00
+    RovP0 = Rdry * rP0
+    P0ovR = PRES00 / Rdry
+
+    s = 1.0_RP 
+    is_panel1to4 = .true.
+    if ( lmesh%panelID == 5 ) then
+      is_panel1to4 = .false.
+    else if ( lmesh%panelID == 6 ) then
+      is_panel1to4 = .false.
+      s = - 1.0_RP
+    end if
+
+    !$omp parallel private(                        &
+    !$omp RHOT_, rdens_, u_, v_, w_, wt_,          &
+    !$omp Fx, Fy, Fz, LiftDelFlx,                  &
+    !$omp drho, GradPhyd_x, GradPhyd_y,            &
+    !$omp G11, G12, G22, GsqrtV, RGsqrtV,          &
+    !$omp X, Y, twoOVdel2,                         &
+    !$omp CORI, ke, ke2D, wk, kp, tmp1, tmp2 )
+
+    !$omp do 
+    do ke2D = lmesh2D%NeS, lmesh2D%NeE
+      do kp=1, elem2D%Np
+        X2D(kp,ke2d) = tan(lmesh2D%pos_en(kp,ke2d,1))
+        Y2D(kp,ke2d) = tan(lmesh2D%pos_en(kp,ke2d,2))
+      end do
+    end do
+
+    !$omp do
+    do ke = lmesh%NeS, lmesh%NeE
+      !--
+      ke2d = lmesh%EMap3Dto2D(ke)
+      do kp=1, elem%Np
+        G11(kp) = lmesh%GIJ(elem%IndexH2Dto3D(kp),ke2d,1,1)
+        G12(kp) = lmesh%GIJ(elem%IndexH2Dto3D(kp),ke2d,1,2)
+        G22(kp) = lmesh%GIJ(elem%IndexH2Dto3D(kp),ke2d,2,2)
+      enddo
+      do kp=1, elem%Np
+        GsqrtV(kp)  = lmesh%Gsqrt(kp,ke) / lmesh%GsqrtH(elem%IndexH2Dto3D(kp),ke2d)
+      enddo
+      do kp=1, elem%Np
+        RGsqrtV(kp) = 1.0_RP / GsqrtV(kp)
+      enddo
+
+      !--
+      do kp=1, elem%Np
+        RHOT_(kp) = P0ovR * ( PRES_hyd(kp,ke) * rP0 )**rgamm + DRHOT_(kp,ke)
+      enddo
+      ! DPRES_(:) = PRES00 * ( Rtot(:,ke) * rP0 * RHOT_(:) )**( CPtot(:,ke) / CVtot(:,ke) ) &
+      !           - PRES_hyd(:,ke)
+
+      do kp=1, elem%Np
+        rdens_(kp) = 1.0_RP / ( DDENS_(kp,ke) + DENS_hyd(kp,ke) )
+      enddo
+      do kp=1, elem%Np
+        u_ (kp) = MOMX_(kp,ke) * rdens_(kp)
+        v_ (kp) = MOMY_(kp,ke) * rdens_(kp)
+        w_ (kp) = MOMZ_(kp,ke) * rdens_(kp)
+      enddo
+      do kp=1, elem%Np
+        wt_(kp) = w_(kp) * RGsqrtV(kp) + lmesh%GI3(kp,ke,1) * u_(kp) + lmesh%GI3(kp,ke,2) * v_(kp) 
+      enddo
+
+
+      !-- Fx:
+      !-- 1 Gradient hydrostatic pressure
+      !-- 2 DENS
+      !-- 3 MOMX
+      !-- 4 MOMY
+      !-- 5 MOMZ
+      !-- 6 RHOT
+      do kp=1, elem%Np
+        wk(1, kp) = GsqrtV(kp) * PRES_hyd(kp,ke)
+        wk(2, kp) = lmesh%Gsqrt(kp,ke) * MOMX_(kp,ke)
+        wk(3, kp) = lmesh%Gsqrt(kp,ke) * ( u_ (kp) * MOMX_(kp,ke) + DPRES_(kp, ke) * G11(kp) )
+        wk(4, kp) = lmesh%Gsqrt(kp,ke) * ( u_ (kp) * MOMY_(kp,ke) + DPRES_(kp, ke) * G12(kp) )
+        wk(5, kp) = lmesh%Gsqrt(kp,ke) * u_ (kp) * MOMZ_(kp,ke)
+        wk(6, kp) = lmesh%Gsqrt(kp,ke) * u_ (kp) * RHOT_(kp)
+      enddo
+      !-- calculate
+      !call fapp_start("ellspmv6", 66, 3)
+      call sparsemat_matmul(Dx, wk, Fx, 6)
+      !call fapp_stop("ellspmv6", 66, 3)
+
+      !-- Fy:
+      !-- 1 Gradient hydrostatic pressure
+      !-- 2 DENS
+      !-- 3 MOMX
+      !-- 4 MOMY
+      !-- 5 MOMZ
+      !-- 6 RHOT
+      ! wk(1, :) = GsqrtV(:) * PRES_hyd(:,ke)
+      do kp=1, elem%Np
+
+        wk(2, kp) = lmesh%Gsqrt(kp,ke) * MOMY_(kp,ke)
+        wk(3, kp) = lmesh%Gsqrt(kp,ke) * ( v_ (kp) * MOMX_(kp,ke) + DPRES_(kp, ke) * G12(kp) )
+        wk(4, kp) = lmesh%Gsqrt(kp,ke) * ( v_ (kp) * MOMY_(kp,ke) + DPRES_(kp, ke) * G22(kp) )
+        wk(5, kp) = lmesh%Gsqrt(kp,ke) * v_ (kp) * MOMZ_(kp,ke)
+        wk(6, kp) = lmesh%Gsqrt(kp,ke) * v_ (kp) * RHOT_(kp)
+      enddo
+      !-- calculate
+      call sparsemat_matmul(Dy, wk, Fy, 6)
+
+      !-- Fz:
+      !-- 1 Gradient hydrostatic pressure
+      !-- 2 Gradient hydrostatic pressure
+      !-- 3 DENS
+      !-- 4 MOMX
+      !-- 5 MOMY
+      !-- 6 MOMZ
+      !-- 7 RHOT
+      do kp=1, elem%Np
+        tmp1 = wk(1, kp)
+
+        wk(1, kp) = tmp1 * lmesh%GI3(kp,ke,1)
+        wk(2, kp) = tmp1 * lmesh%GI3(kp,ke,2)
+      enddo
+      do kp=1, elem%Np
+        wk(3, kp) = lmesh%Gsqrt(kp,ke) * wt_(kp) * ( DDENS_(kp,ke) + DENS_hyd(kp,ke) )     
+        wk(4, kp) = lmesh%Gsqrt(kp,ke) * ( wt_(kp) * MOMX_(kp,ke) + DPRES_(kp,ke) * ( lmesh%GI3(kp,ke,1) * G11(kp) + lmesh%GI3(kp,ke,2) * G12(kp) ) )
+        wk(5, kp) = lmesh%Gsqrt(kp,ke) * ( wt_(kp) * MOMY_(kp,ke) + DPRES_(kp,ke) * ( lmesh%GI3(kp,ke,1) * G12(kp) + lmesh%GI3(kp,ke,2) * G22(kp) ) ) 
+        wk(6, kp) = lmesh%Gsqrt(kp,ke) * ( wt_(kp) * MOMZ_(kp,ke) + DPRES_(kp,ke) * RGsqrtV(kp) )
+        wk(7, kp) = lmesh%Gsqrt(kp,ke) * wt_(kp) * RHOT_(kp)
+      enddo
+      !-- calculate
+      !call fapp_start("ellspmv7", 67, 3)
+      call sparsemat_matmul(Dz, wk, Fz, 7, 7)
+      !call fapp_stop("ellspmv7", 67, 3)
+
+      !-- LiftDelFlx:
+      !-- 1 Gradient hydrostatic pressure
+      !-- 2 Gradient hydrostatic pressure
+      !-- 3 DENS
+      !-- 4 RHOT
+      !-- 5 MOMZ
+      !-- 6 MOMX
+      !-- 7 MOMY
+      do kp=1, elem%Np
+        ! wk(kp, 3) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,DENS_VID)
+        ! wk(kp, 4) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,MOMX_VID)
+        ! wk(kp, 5) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,MOMY_VID)
+        ! wk(kp, 6) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,MOMZ_VID)
+        ! wk(kp, 7) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,RHOT_VID)
+
+        wk(1, kp) = lmesh%Fscale(kp,ke) * del_flux_hyd(kp,ke,1)
+        wk(2, kp) = lmesh%Fscale(kp,ke) * del_flux_hyd(kp,ke,2)
+        wk(3, kp) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,DENS_VID)
+        wk(4, kp) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,RHOT_VID)
+        wk(5, kp) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,MOMZ_VID)
+        wk(6, kp) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,MOMX_VID)
+        wk(7, kp) = lmesh%Fscale(kp,ke) * del_flux(kp,ke,MOMY_VID)
+      enddo
+      !-- calculate
+      call sparsemat_matmul(Lift, wk, LiftDelFlx, 7, 7)
+      
+      do kp=1, elem%Np
+        X(kp) = X2D(elem%IndexH2Dto3D(kp),ke2d)
+        Y(kp) = Y2D(elem%IndexH2Dto3D(kp),ke2d)
+      enddo
+
+      do kp=1, elem%Np
+        twoOVdel2(kp) = 2.0_RP / ( 1.0_RP + X(kp)**2 + Y(kp)**2 )
+      enddo
+
+      do kp=1, elem%Np
+        CORI(kp,1) = s * OHM * twoOVdel2(kp) * ( - X(kp) * Y(kp)          * MOMX_(kp,ke) + ( 1.0_RP + X(kp)**2 ) * MOMY_(kp,ke) )
+        CORI(kp,2) = s * OHM * twoOVdel2(kp) * ( - ( 1.0_RP + Y(kp)**2 ) * MOMX_(kp,ke) +  X(kp) * Y(kp)         * MOMY_(kp,ke) )
+      enddo
+      if ( is_panel1to4 ) then
+        do kp=1, elem%Np
+          CORI(kp,1) = s * Y(kp) * CORI(kp,1)
+          CORI(kp,2) = s * Y(kp) * CORI(kp,2)
+        enddo
+      end if
+
+      drho(:) = matmul(IntrpMat_VPOrdM1, DDENS_(:,ke))
+
+      !-- Gradient hydrostatic pressure
+      do kp=1, elem%Np
+        GradPhyd_x(kp) = lmesh%Escale(kp,ke,1,1) * Fx(kp,1) &
+                      + lmesh%Escale(kp,ke,3,3) * Fz(kp,1) &
+                      + LiftDelFlx(kp,1)
+
+        GradPhyd_y(kp) = lmesh%Escale(kp,ke,2,2) * Fy(kp,1) &
+                      + lmesh%Escale(kp,ke,3,3) * Fz(kp,2) &
+                      + LiftDelFlx(kp,2)
+      enddo
+      
+      !-- DENS
+      do kp = 1, elem%Np
+        DENS_dt(kp,ke) = - ( &
+              lmesh%Escale(kp,ke,1,1) * Fx(kp,2)     &
+            + lmesh%Escale(kp,ke,2,2) * Fy(kp,2)     &
+            + lmesh%Escale(kp,ke,3,3) * Fz(kp,3)     &
+            + LiftDelFlx(kp,3) ) / lmesh%Gsqrt(kp,ke)
+      enddo
+      
+      !-- MOMX
+      do kp=1, elem%Np
+        MOMX_dt(kp,ke) = &
+            - ( lmesh%Escale(kp,ke,1,1) * Fx(kp,3)                                         &
+              + lmesh%Escale(kp,ke,2,2) * Fy(kp,3)                                         &
+              + lmesh%Escale(kp,ke,3,3) * Fz(kp,4)                                         &
+              + LiftDelFlx(kp,6)                   ) / lmesh%Gsqrt(kp,ke)                  &
+            - twoOVdel2(kp) * Y(kp) *                                                    &
+              ( X(kp) * Y(kp) * u_(kp) - (1.0_RP + Y(kp)**2) * v_(kp) ) * MOMX_(kp,ke)       &
+            - ( G11(kp) * GradPhyd_x(kp) + G12(kp) * GradPhyd_y(kp) ) * RGsqrtV(kp)         &
+            + CORI(kp,1)              
+      enddo
+
+      !-- MOMY
+      do kp=1, elem%Np
+        MOMY_dt(kp,ke) = &
+              - ( lmesh%Escale(kp,ke,1,1) * Fx(kp,4)                                         &
+                + lmesh%Escale(kp,ke,2,2) * Fy(kp,4)                                         &
+                + lmesh%Escale(kp,ke,3,3) * Fz(kp,5)                                         &
+                + LiftDelFlx(kp,7)                  ) / lmesh%Gsqrt(kp,ke)                   &
+              - twoOVdel2(kp) * X(kp) *                                                    &
+                ( - (1.0_RP + X(kp)**2) * u_(kp) + X(kp) * Y(kp) * v_(kp) ) * MOMY_(kp,ke)     &
+              - ( G12(kp) * GradPhyd_x(kp) + G22(kp) * GradPhyd_y(kp) ) * RGsqrtV(kp)         &
+              + CORI(kp,2) 
+      enddo
+
+      !-- MOMZ
+      do kp=1, elem%Np
+        MOMZ_dt(kp,ke) = &
+            - ( lmesh%Escale(kp,ke,1,1) * Fx(kp,5)       &
+              + lmesh%Escale(kp,ke,2,2) * Fy(kp,5)       &
+              + lmesh%Escale(kp,ke,3,3) * Fz(kp,6)       &
+              + LiftDelFlx(kp,5) ) / lmesh%Gsqrt(kp,ke)  &
+            - Grav * drho(kp)
+      enddo
+
+      !-- RHOT
+      do kp=1, elem%Np
+        RHOT_dt(kp,ke) = &
+            - ( lmesh%Escale(kp,ke,1,1) * Fx(kp,6)      &
+              + lmesh%Escale(kp,ke,2,2) * Fy(kp,6)      &
+              + lmesh%Escale(kp,ke,3,3) * Fz(kp,7)      &
+              + LiftDelFlx(kp,4) ) / lmesh%Gsqrt(kp,ke) 
+      enddo
+    
+    end do
+    !$omp end do
+    !$omp end parallel
+    call PROF_rapend('cal_dyn_tend_interior', 3)
+
+    return
+  end subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_shallow_atm
+
+
+!OCL SERIAL
+subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_deep_atm( &
+    DENS_dt, MOMX_dt, MOMY_dt, MOMZ_dt, RHOT_dt,                                & ! (out)
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd, CORIOLIS,  & ! (in)
+    Rtot, CVtot, CPtot,                                                         & ! (in)
+    Dx, Dy, Dz, Sx, Sy, Sz, Lift, lmesh, elem, lmesh2D, elem2D )                  ! (in)
+
+    use scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux, only: &
+      get_ebnd_flux => atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalhvc
+    use scale_const, only: &
+      OHM => CONST_OHM
+    implicit none
+
+    class(LocalMesh3D), intent(in) :: lmesh
+    class(ElementBase3D), intent(in) :: elem
+    class(LocalMesh2D), intent(in) :: lmesh2D
+    class(ElementBase2D), intent(in) :: elem2D
+    type(SparseMat), intent(in) :: Dx, Dy, Dz, Sx, Sy, Sz, Lift
+    real(RP), intent(out) :: DENS_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMX_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMY_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: MOMZ_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(out) :: RHOT_dt(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DDENS_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMX_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMY_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: MOMZ_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DRHOT_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DPRES_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DENS_hyd(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: PRES_hyd(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: CORIOLIS(elem2D%Np,lmesh2D%NeA)
+    real(RP), intent(in)  :: Rtot (elem%Np,lmesh%NeA)    
+    real(RP), intent(in)  :: CVtot(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: CPtot(elem%Np,lmesh%NeA)
+
+    real(RP) :: Fx(elem%Np), Fy(elem%Np), Fz(elem%Np), LiftDelFlx(elem%Np)
+    real(RP) :: GradPhyd_x(elem%Np), GradPhyd_y(elem%Np)
+    real(RP) :: del_flux(elem%NfpTot,lmesh%Ne,PRGVAR_NUM)
+    real(RP) :: del_flux_hyd(elem%NfpTot,lmesh%Ne,2)
+    real(RP) :: RHOT_(elem%Np)
+    real(RP) :: rdens_(elem%Np), u_(elem%Np), v_(elem%Np), w_(elem%Np), wt_(elem%np), drho(elem%Np)
+
+    real(RP) :: G11(elem%Np), G12(elem%Np), G22(elem%Np)
+    real(RP) :: GsqrtV(elem%Np), RGsqrtV(elem%Np), Rgam2(elem%Np)
+    real(RP) :: X2D(elem2D%Np,lmesh2D%Ne), Y2D(elem2D%Np,lmesh2D%Ne)
+    real(RP) :: X(elem%Np), Y(elem%Np), twoOVdel2(elem%Np)
+    real(RP) :: OM1(elem%Np), OM2(elem%Np), OM3(elem%Np), DEL(elem%Np), R(elem%Np)
+    logical :: is_panel1to4
+    real(RP) :: s
+
+    integer :: ke, ke2d
+    integer :: p
+    
+    real(RP) :: rgamm    
+    real(RP) :: rP0
+    real(RP) :: P0ovR
+    !------------------------------------------------------------------------
+
+    call PROF_rapstart('cal_dyn_tend_bndflux', 3)
+    call get_ebnd_flux( &
+      del_flux, del_flux_hyd,                                                  & ! (out)
+      DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd,         & ! (in)
+      Rtot, CVtot, CPtot,                                                      & ! (in)
+      lmesh%Gsqrt, lmesh%GIJ(:,:,1,1), lmesh%GIJ(:,:,1,2), lmesh%GIJ(:,:,2,2), & ! (in)
+      lmesh%GsqrtH, lmesh%gam, lmesh%GI3(:,:,1), lmesh%GI3(:,:,2),             & ! (in)    
+      lmesh%normal_fn(:,:,1), lmesh%normal_fn(:,:,2), lmesh%normal_fn(:,:,3),  & ! (in)
+      lmesh%vmapM, lmesh%vmapP, elem%IndexH2Dto3D_bnd,                         & ! (in)
+      lmesh, elem, lmesh2D, elem2D                                             ) ! (in)
+    call PROF_rapend('cal_dyn_tend_bndflux', 3)
+ 
+    !-----
+    call PROF_rapstart('cal_dyn_tend_interior', 3)
+    rgamm = CvDry / CpDry
+    rP0   = 1.0_RP / PRES00
+    P0ovR = PRES00 / Rdry
+
+    s = 2.0_RP * OHM
+    is_panel1to4 = .true.
+    if ( lmesh%panelID == 5 ) then
+      is_panel1to4 = .false.
+    else if ( lmesh%panelID == 6 ) then
+      is_panel1to4 = .false.
+      s = - s
+    end if
+
+    !$omp parallel private(                        &
+    !$omp RHOT_, rdens_, u_, v_, w_, wt_,          &
+    !$omp Fx, Fy, Fz, LiftDelFlx,                  &
+    !$omp drho, GradPhyd_x, GradPhyd_y,            &
+    !$omp G11, G12, G22, Rgam2, GsqrtV, RGsqrtV,   &
+    !$omp X, Y, twoOVdel2,                         &
+    !$omp OM1, OM2, OM3, DEL, R, ke, ke2D          )
+
+    !$omp do
+    do ke2D = lmesh2D%NeS, lmesh2D%NeE
+      X2D(:,ke2d) = tan(lmesh2D%pos_en(:,ke2d,1))
+      Y2D(:,ke2d) = tan(lmesh2D%pos_en(:,ke2d,2))
+    end do
+
+    !$omp do
+    do ke = lmesh%NeS, lmesh%NeE
+      !--
+      ke2d = lmesh%EMap3Dto2D(ke)
+      Rgam2(:) = 1.0_RP / lmesh%gam(:,ke)**2
+      G11(:) = lmesh%GIJ(elem%IndexH2Dto3D,ke2d,1,1) * Rgam2(:)
+      G12(:) = lmesh%GIJ(elem%IndexH2Dto3D,ke2d,1,2) * Rgam2(:)
+      G22(:) = lmesh%GIJ(elem%IndexH2Dto3D,ke2d,2,2) * Rgam2(:)
+      GsqrtV(:)  = lmesh%Gsqrt(:,ke) * Rgam2(:) / lmesh%GsqrtH(elem%IndexH2Dto3D,ke2d)
+      RGsqrtV(:) = 1.0_RP / GsqrtV(:)
+
+      !--
+      RHOT_(:) = P0ovR * ( PRES_hyd(:,ke) * rP0 )**rgamm + DRHOT_(:,ke)
+      ! DPRES_(:) = PRES00 * ( Rtot(:,ke) * rP0 * RHOT_(:) )**( CPtot(:,ke) / CVtot(:,ke) ) &
+      !           - PRES_hyd(:,ke)
+
+      rdens_(:) = 1.0_RP / ( DDENS_(:,ke) + DENS_hyd(:,ke) )
+      u_ (:) = MOMX_(:,ke) * rdens_(:)
+      v_ (:) = MOMY_(:,ke) * rdens_(:)
+      w_ (:) = MOMZ_(:,ke) * rdens_(:)
+      wt_(:) = w_(:) * RGsqrtV(:) + lmesh%GI3(:,ke,1) * u_(:) + lmesh%GI3(:,ke,2) * v_(:) 
+
+      X(:) = X2D(elem%IndexH2Dto3D,ke2d)
+      Y(:) = Y2D(elem%IndexH2Dto3D,ke2d)
+      DEL(:) = sqrt( 1.0_RP + X(:)**2 + Y(:)**2 )
+      twoOVdel2(:) = 2.0_RP / ( 1.0_RP + X(:)**2 + Y(:)**2 )
+
+      R(:) = RPlanet * lmesh%gam(:,ke)
+
+      !-  pnl=1~4: OM1:                     0, OM2: s del / (r (1+Y^2)) ,   s OM3 : Y /del
+      !-  pnl=5,6: OM1: - s X del/(r (1+X^2)), OM2: -  s Y del/(r(1+Y^2)), OM3 : s/del
+      if ( is_panel1to4 ) then
+        OM1(:) = 0.0_RP
+        OM2(:) = s * DEL(:) / ( R(:) * ( 1.0_RP + Y(:)**2 ) )
+        OM3(:) = s * Y(:) / DEL(:)
+      else
+        OM1(:) = - s * X(:) * DEL(:) / ( R(:) * ( 1.0_RP + X(:)**2 ) )
+        OM2(:) = - s * Y(:) * DEL(:) / ( R(:) * ( 1.0_RP + Y(:)**2 ) )
+        OM3(:) =   s / DEL(:)
+      end if
+
+      drho(:) = matmul(IntrpMat_VPOrdM1, DDENS_(:,ke))
+
+      !-- Gradient hydrostatic pressure
+      
+      call sparsemat_matmul(Dx, GsqrtV(:) * PRES_hyd(:,ke), Fx)
+      call sparsemat_matmul(Dz, GsqrtV(:) * lmesh%GI3(:,ke,1) * PRES_hyd(:,ke), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux_hyd(:,ke,1), LiftDelFlx)
+      GradPhyd_x(:) = lmesh%Escale(:,ke,1,1) * Fx(:) &
+                    + lmesh%Escale(:,ke,3,3) * Fz(:) &
+                    + LiftDelFlx(:)
+
+      call sparsemat_matmul(Dy, GsqrtV(:) * PRES_hyd(:,ke), Fy)
+      call sparsemat_matmul(Dz, GsqrtV(:) * lmesh%GI3(:,ke,2) * PRES_hyd(:,ke), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux_hyd(:,ke,2), LiftDelFlx)
+      GradPhyd_y(:) = lmesh%Escale(:,ke,2,2) * Fy(:) &
+                    + lmesh%Escale(:,ke,3,3) * Fz(:) &
+                    + LiftDelFlx(:)
+      
+      !-- DENS
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * MOMX_(:,ke), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * MOMY_(:,ke), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( DDENS_(:,ke) + DENS_hyd(:,ke) ) * wt_(:), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,DENS_VID), LiftDelFlx)
+
+      DENS_dt(:,ke) = - ( &
+            lmesh%Escale(:,ke,1,1) * Fx(:)     &
+          + lmesh%Escale(:,ke,2,2) * Fy(:)     &
+          + lmesh%Escale(:,ke,3,3) * Fz(:)     &
+          + LiftDelFlx(:) ) / lmesh%Gsqrt(:,ke)
+      
+      !-- MOMX
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * ( u_ (:) * MOMX_(:,ke) + G11(:) * DPRES_(:,ke) ), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * ( v_ (:) * MOMX_(:,ke) + G12(:) * DPRES_(:,ke) ), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( wt_(:) * MOMX_(:,ke)                              &
+                                                    + ( lmesh%GI3(:,ke,1) * G11(:) + lmesh%GI3(:,ke,2) * G12(:) ) * DPRES_(:,ke) ), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,MOMX_VID), LiftDelFlx)
+
+      MOMX_dt(:,ke) = &
+          - ( lmesh%Escale(:,ke,1,1) * Fx(:)                                                &
+            + lmesh%Escale(:,ke,2,2) * Fy(:)                                                &
+            + lmesh%Escale(:,ke,3,3) * Fz(:)                                                &
+            + LiftDelFlx(:)                   ) / lmesh%Gsqrt(:,ke)                         &
+          - twoOVdel2(:) * Y(:) *                                                           & !-> metric terms
+            ( X(:) * Y(:) * u_(:) - ( 1.0_RP + Y(:)**2 ) * v_(:) ) * MOMX_(:,ke)            & !
+          - 2.0_RP * u_(:) * MOMZ_(:,ke) / R(:)                                             & !<-
+          - ( G11(:) * GradPhyd_x(:) + G12(:) * GradPhyd_y(:) ) * RGsqrtV(:)                & !-> gradient hydrostatic pressure
+          - lmesh%Gsqrt(:,ke) * (  G11(:) * ( OM2(:) * MOMZ_(:,ke) - OM3(:) * MOMY_(:,ke) ) & !-> Coriolis term
+                                 - G12(:) * ( OM1(:) * MOMZ_(:,ke) - OM3(:) * MOMX_(:,ke) ) )
+
+      !-- MOMY
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * ( u_ (:) * MOMY_(:,ke) + G12(:) * DPRES_(:,ke) ), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * ( v_ (:) * MOMY_(:,ke) + G22(:) * DPRES_(:,ke) ), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( wt_(:) * MOMY_(:,ke)                              &
+                                                    + ( lmesh%GI3(:,ke,1) * G12(:) + lmesh%GI3(:,ke,2) * G22(:) ) * DPRES_(:,ke) ), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,MOMY_VID), LiftDelFlx)
+
+      MOMY_dt(:,ke) = &
+            - ( lmesh%Escale(:,ke,1,1) * Fx(:)                                                &
+              + lmesh%Escale(:,ke,2,2) * Fy(:)                                                &
+              + lmesh%Escale(:,ke,3,3) * Fz(:)                                                &
+              + LiftDelFlx(:)                  ) / lmesh%Gsqrt(:,ke)                          &
+            - twoOVdel2(:) * X(:) *                                                           & !-> metric terms
+              ( - (1.0_RP + X(:)**2) * u_(:) + X(:) * Y(:) * v_(:) ) * MOMY_(:,ke)            & !
+            - 2.0_RP * v_(:) * MOMZ_(:,ke) / R(:)                                             & !<-
+            - ( G12(:) * GradPhyd_x(:) + G22(:) * GradPhyd_y(:) ) * RGsqrtV(:)                & !-> gradient hydrostatic pressure
+            - lmesh%Gsqrt(:,ke) * (  G12(:) * ( OM2(:) * MOMZ_(:,ke) - OM3(:) * MOMY_(:,ke) ) & !-> Coriolis term
+                                   - G22(:) * ( OM1(:) * MOMZ_(:,ke) - OM3(:) * MOMX_(:,ke) ) )
+
+      !-- MOMZ
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) *   u_ (:) * MOMZ_(:,ke), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) *   v_ (:) * MOMZ_(:,ke), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * ( wt_(:) * MOMZ_(:,ke) + RGsqrtV(:) * DPRES_(:,ke) ), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,MOMZ_VID), LiftDelFlx)
+      
+      MOMZ_dt(:,ke) = &
+          - ( lmesh%Escale(:,ke,1,1) * Fx(:)                                                                    &
+            + lmesh%Escale(:,ke,2,2) * Fy(:)                                                                    &
+            + lmesh%Escale(:,ke,3,3) * Fz(:)                                                                    &
+            + LiftDelFlx(:) ) / lmesh%Gsqrt(:,ke)                                                               &
+          - 0.25_RP * R(:) * twoOVdel2(:)**2 * ( 1.0_RP * X(:)**2 ) * ( 1.0_RP * Y(:)**2 )                      & !-> metric terms
+            * ( - ( 1.0_RP + X(:)**2 ) * MOMX_(:,ke) * u_(:)                                                    & !
+                + 2.0_RP * X(:) * Y(:) * MOMX_(:,ke) * v_(:)                                                    & !
+                - ( 1.0_RP + Y(:)**2 ) * MOMY_(:,ke) * v_(:)  )                                                 & !<-
+          + 2.0_RP * DPRES_(:,ke) / R(:)                                                                        & !-> metric term with gradient of pressure deviaition
+          - lmesh%Gsqrt(:,ke) * ( OM1(:) * MOMY_(:,ke) - OM2(:) * MOMX_(:,ke) )                                 & !-> Coriolis term
+          - Grav * Rgam2(:) * drho(:)                                                                             !-> buoyancy term
+
+      !-- RHOT
+      call sparsemat_matmul(Dx, lmesh%Gsqrt(:,ke) * u_ (:) * RHOT_(:), Fx)
+      call sparsemat_matmul(Dy, lmesh%Gsqrt(:,ke) * v_ (:) * RHOT_(:), Fy)
+      call sparsemat_matmul(Dz, lmesh%Gsqrt(:,ke) * wt_(:) * RHOT_(:), Fz)
+      call sparsemat_matmul(Lift, lmesh%Fscale(:,ke) * del_flux(:,ke,RHOT_VID), LiftDelFlx)
+      
+      RHOT_dt(:,ke) = &
+          - ( lmesh%Escale(:,ke,1,1) * Fx(:)      &
+            + lmesh%Escale(:,ke,2,2) * Fy(:)      &
+            + lmesh%Escale(:,ke,3,3) * Fz(:)      &
+            + LiftDelFlx(:) ) / lmesh%Gsqrt(:,ke) 
+    end do
+    !$omp end do
+    !$omp end parallel
+    call PROF_rapend('cal_dyn_tend_interior', 3)
+
+    return
+  end subroutine atm_dyn_dgm_globalnonhydro3d_rhot_heve_cal_tend_deep_atm
+
+end module scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter.F90
@@ -184,7 +184,7 @@ contains
     real(RP), intent(inout) :: q_in(12, 12, 12)
     real(RP), intent(inout) :: q_tmp(12, 12, 12)
     
-    real(RP) :: tmp1, tmp2
+    real(RP) :: tmp1, tmp2, tmp3
     integer :: i, j, k
 
     !-- x direction
@@ -195,18 +195,19 @@ contains
       tmp1 = filterMat(i,1)  * q_in(1,j,k) + &
              filterMat(i,2)  * q_in(2,j,k) + &
              filterMat(i,3)  * q_in(3,j,k) + & 
-             filterMat(i,4)  * q_in(4,j,k) + & 
-             filterMat(i,5)  * q_in(5,j,k) + & 
+             filterMat(i,4)  * q_in(4,j,k)
+              
+      tmp2 = filterMat(i,5)  * q_in(5,j,k) + & 
              filterMat(i,6)  * q_in(6,j,k) + & 
              filterMat(i,7)  * q_in(7,j,k) + & 
              filterMat(i,8)  * q_in(8,j,k) 
 
-      tmp2 = filterMat(i,9)  * q_in(9,j,k) + & 
+      tmp3 = filterMat(i,9)  * q_in(9,j,k) + & 
              filterMat(i,10) * q_in(10,j,k) + & 
              filterMat(i,11) * q_in(11,j,k) + & 
              filterMat(i,12) * q_in(12,j,k)  
 
-      q_tmp(i,j,k) = tmp1 + tmp2
+      q_tmp(i,j,k) = tmp1 + tmp2 + tmp3
 
     end do
     end do
@@ -220,18 +221,19 @@ contains
       tmp1 = q_tmp(i,1,k)  * filterMat_tr(1,j) + &
              q_tmp(i,2,k)  * filterMat_tr(2,j) + &
              q_tmp(i,3,k)  * filterMat_tr(3,j) + &
-             q_tmp(i,4,k)  * filterMat_tr(4,j) + &
-             q_tmp(i,5,k)  * filterMat_tr(5,j) + &
+             q_tmp(i,4,k)  * filterMat_tr(4,j)
+
+      tmp2 = q_tmp(i,5,k)  * filterMat_tr(5,j) + &
              q_tmp(i,6,k)  * filterMat_tr(6,j) + &
              q_tmp(i,7,k)  * filterMat_tr(7,j) + &
              q_tmp(i,8,k)  * filterMat_tr(8,j)
 
-      tmp2 = q_tmp(i,9,k)  * filterMat_tr(9,j) + &
+      tmp3 = q_tmp(i,9,k)  * filterMat_tr(9,j) + &
              q_tmp(i,10,k) * filterMat_tr(10,j) + &
              q_tmp(i,11,k) * filterMat_tr(11,j) + &
              q_tmp(i,12,k) * filterMat_tr(12,j) 
 
-      q_in(i,j,k) = tmp1 + tmp2
+      q_in(i,j,k) = tmp1 + tmp2 + tmp3
 
     end do
     end do
@@ -245,18 +247,19 @@ contains
       tmp1 = q_in(i,j,1)  * filterMat_tr(1,k) + &
              q_in(i,j,2)  * filterMat_tr(2,k) + &
              q_in(i,j,3)  * filterMat_tr(3,k) + &
-             q_in(i,j,4)  * filterMat_tr(4,k) + &
-             q_in(i,j,5)  * filterMat_tr(5,k) + &
+             q_in(i,j,4)  * filterMat_tr(4,k)
+
+      tmp2 = q_in(i,j,5)  * filterMat_tr(5,k) + &
              q_in(i,j,6)  * filterMat_tr(6,k) + &
              q_in(i,j,7)  * filterMat_tr(7,k) + &
              q_in(i,j,8)  * filterMat_tr(8,k)
 
-      tmp2 = q_in(i,j,9)  * filterMat_tr(9,k) + &
+      tmp3 = q_in(i,j,9)  * filterMat_tr(9,k) + &
              q_in(i,j,10) * filterMat_tr(10,k) + &
              q_in(i,j,11) * filterMat_tr(11,k) + &
              q_in(i,j,12) * filterMat_tr(12,k) 
 
-      q_tmp(i,j,k) = tmp1 + tmp2
+      q_tmp(i,j,k) = tmp1 + tmp2 + tmp3
 
     end do
     end do

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter.F90
@@ -184,6 +184,7 @@ contains
     real(RP), intent(inout) :: q_in(12, 12, 12)
     real(RP), intent(inout) :: q_tmp(12, 12, 12)
     
+    real(RP) :: tmp1, tmp2
     integer :: i, j, k
 
     !-- x direction
@@ -191,18 +192,21 @@ contains
     do j=1, 12
     do i=1, 12
 
-      q_tmp(i,j,k) = filterMat(i,1)  * q_in(1,j,k) + &
-                     filterMat(i,2)  * q_in(2,j,k) + &
-                     filterMat(i,3)  * q_in(3,j,k) + & 
-                     filterMat(i,4)  * q_in(4,j,k) + & 
-                     filterMat(i,5)  * q_in(5,j,k) + & 
-                     filterMat(i,6)  * q_in(6,j,k) + & 
-                     filterMat(i,7)  * q_in(7,j,k) + & 
-                     filterMat(i,8)  * q_in(8,j,k) + & 
-                     filterMat(i,9)  * q_in(9,j,k) + & 
-                     filterMat(i,10) * q_in(10,j,k) + & 
-                     filterMat(i,11) * q_in(11,j,k) + & 
-                     filterMat(i,12) * q_in(12,j,k)  
+      tmp1 = filterMat(i,1)  * q_in(1,j,k) + &
+             filterMat(i,2)  * q_in(2,j,k) + &
+             filterMat(i,3)  * q_in(3,j,k) + & 
+             filterMat(i,4)  * q_in(4,j,k) + & 
+             filterMat(i,5)  * q_in(5,j,k) + & 
+             filterMat(i,6)  * q_in(6,j,k) + & 
+             filterMat(i,7)  * q_in(7,j,k) + & 
+             filterMat(i,8)  * q_in(8,j,k) 
+
+      tmp2 = filterMat(i,9)  * q_in(9,j,k) + & 
+             filterMat(i,10) * q_in(10,j,k) + & 
+             filterMat(i,11) * q_in(11,j,k) + & 
+             filterMat(i,12) * q_in(12,j,k)  
+
+      q_tmp(i,j,k) = tmp1 + tmp2
 
     end do
     end do
@@ -213,18 +217,21 @@ contains
     do j=1, 12
     do i=1, 12
 
-      q_in(i,j,k) = q_tmp(i,1,k)  * filterMat_tr(1,j) + &
-                    q_tmp(i,2,k)  * filterMat_tr(2,j) + &
-                    q_tmp(i,3,k)  * filterMat_tr(3,j) + &
-                    q_tmp(i,4,k)  * filterMat_tr(4,j) + &
-                    q_tmp(i,5,k)  * filterMat_tr(5,j) + &
-                    q_tmp(i,6,k)  * filterMat_tr(6,j) + &
-                    q_tmp(i,7,k)  * filterMat_tr(7,j) + &
-                    q_tmp(i,8,k)  * filterMat_tr(8,j) + &
-                    q_tmp(i,9,k)  * filterMat_tr(9,j) + &
-                    q_tmp(i,10,k) * filterMat_tr(10,j) + &
-                    q_tmp(i,11,k) * filterMat_tr(11,j) + &
-                    q_tmp(i,12,k) * filterMat_tr(12,j) 
+      tmp1 = q_tmp(i,1,k)  * filterMat_tr(1,j) + &
+             q_tmp(i,2,k)  * filterMat_tr(2,j) + &
+             q_tmp(i,3,k)  * filterMat_tr(3,j) + &
+             q_tmp(i,4,k)  * filterMat_tr(4,j) + &
+             q_tmp(i,5,k)  * filterMat_tr(5,j) + &
+             q_tmp(i,6,k)  * filterMat_tr(6,j) + &
+             q_tmp(i,7,k)  * filterMat_tr(7,j) + &
+             q_tmp(i,8,k)  * filterMat_tr(8,j)
+
+      tmp2 = q_tmp(i,9,k)  * filterMat_tr(9,j) + &
+             q_tmp(i,10,k) * filterMat_tr(10,j) + &
+             q_tmp(i,11,k) * filterMat_tr(11,j) + &
+             q_tmp(i,12,k) * filterMat_tr(12,j) 
+
+      q_in(i,j,k) = tmp1 + tmp2
 
     end do
     end do
@@ -235,18 +242,21 @@ contains
     do j=1, 12
     do i=1, 12
 
-      q_tmp(i,j,k) = q_in(i,j,1)  * filterMat_tr(1,k) + &
-                     q_in(i,j,2)  * filterMat_tr(2,k) + &
-                     q_in(i,j,3)  * filterMat_tr(3,k) + &
-                     q_in(i,j,4)  * filterMat_tr(4,k) + &
-                     q_in(i,j,5)  * filterMat_tr(5,k) + &
-                     q_in(i,j,6)  * filterMat_tr(6,k) + &
-                     q_in(i,j,7)  * filterMat_tr(7,k) + &
-                     q_in(i,j,8)  * filterMat_tr(8,k) + &
-                     q_in(i,j,9)  * filterMat_tr(9,k) + &
-                     q_in(i,j,10) * filterMat_tr(10,k) + &
-                     q_in(i,j,11) * filterMat_tr(11,k) + &
-                     q_in(i,j,12) * filterMat_tr(12,k) 
+      tmp1 = q_in(i,j,1)  * filterMat_tr(1,k) + &
+             q_in(i,j,2)  * filterMat_tr(2,k) + &
+             q_in(i,j,3)  * filterMat_tr(3,k) + &
+             q_in(i,j,4)  * filterMat_tr(4,k) + &
+             q_in(i,j,5)  * filterMat_tr(5,k) + &
+             q_in(i,j,6)  * filterMat_tr(6,k) + &
+             q_in(i,j,7)  * filterMat_tr(7,k) + &
+             q_in(i,j,8)  * filterMat_tr(8,k) + &
+
+      tmp2 = q_in(i,j,9)  * filterMat_tr(9,k) + &
+             q_in(i,j,10) * filterMat_tr(10,k) + &
+             q_in(i,j,11) * filterMat_tr(11,k) + &
+             q_in(i,j,12) * filterMat_tr(12,k) 
+
+      q_tmp(i,j,k) = tmp1 + tmp2
 
     end do
     end do

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter.F90
@@ -249,7 +249,7 @@ contains
              q_in(i,j,5)  * filterMat_tr(5,k) + &
              q_in(i,j,6)  * filterMat_tr(6,k) + &
              q_in(i,j,7)  * filterMat_tr(7,k) + &
-             q_in(i,j,8)  * filterMat_tr(8,k) + &
+             q_in(i,j,8)  * filterMat_tr(8,k)
 
       tmp2 = q_in(i,j,9)  * filterMat_tr(9,k) + &
              q_in(i,j,10) * filterMat_tr(10,k) + &

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_orig.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_orig.F90
@@ -1,0 +1,174 @@
+!-------------------------------------------------------------------------------
+!> module FElib / Fluid dyn solver / Atmosphere / Common / Modal filter
+!!
+!! @par Description
+!!      Modal filter for Atmospheric dynamical process. 
+!!      The modal filter surpresses the numerical instability due to the aliasing errors. 
+!!
+!! @author Team SCALE
+!<
+!-------------------------------------------------------------------------------
+#include "scaleFElib.h"
+module scale_atm_dyn_dgm_modalfilter
+  !-----------------------------------------------------------------------------
+  !
+  !++ Used modules
+  !
+  use scale_precision
+  use scale_io
+
+  use scale_element_base, only: ElementBase
+  use scale_localmesh_base, only: LocalMeshBase
+  use scale_element_modalfilter, only: ModalFilter
+
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public procedures
+  !
+  public :: atm_dyn_dgm_modalfilter_apply
+  public :: atm_dyn_dgm_tracer_modalfilter_apply
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public parameters & variables
+  !
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedures & variables
+  !
+  !-------------------
+contains
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_modalfilter_apply(  &
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_,     & ! (inout)
+    lmesh, elem, filter, do_weight_Gsqrt     ) ! (in)
+
+    implicit none
+
+    class(LocalMeshBase), intent(in) :: lmesh
+    class(ElementBase), intent(in) :: elem    
+    real(RP), intent(inout)  :: DDENS_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMX_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMY_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMZ_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: DRHOT_(elem%Np,lmesh%NeA)
+    class(ModalFilter), intent(in) :: filter
+    logical, intent(in), optional :: do_weight_Gsqrt
+    
+    integer :: ke
+    real(RP) :: tmp(elem%Np,5)
+    integer :: ii, kk
+    real(RP) :: Mik
+    logical :: do_weight_Gsqrt_
+    real(RP) :: RGsqrt(elem%Np)
+    !------------------------------------
+
+    if ( present( do_weight_Gsqrt ) ) then
+      do_weight_Gsqrt_ = do_weight_Gsqrt
+    else
+      do_weight_Gsqrt_ = .false.
+    end if
+
+    if ( do_weight_Gsqrt_ ) then
+      !$omp parallel do private( tmp, ii, kk, Mik, RGsqrt )
+      do ke=lmesh%NeS, lmesh%NeE
+
+        tmp(:,:) = 0.0_RP
+        do ii=1, elem%Np
+        do kk=1, elem%Np
+          Mik = filter%FilterMat(ii,kk) * lmesh%Gsqrt(kk,ke)
+
+          tmp(ii,1) = tmp(ii,1) + Mik * DDENS_(kk,ke)
+          tmp(ii,2) = tmp(ii,2) + Mik * MOMX_ (kk,ke)
+          tmp(ii,3) = tmp(ii,3) + Mik * MOMY_ (kk,ke)
+          tmp(ii,4) = tmp(ii,4) + Mik * MOMZ_ (kk,ke)
+          tmp(ii,5) = tmp(ii,5) + Mik * DRHOT_(kk,ke)
+        end do
+        end do
+
+        RGsqrt(:) = 1.0_RP / lmesh%Gsqrt(:,ke)
+        DDENS_(:,ke) = tmp(:,1) * RGsqrt(:)
+        MOMX_ (:,ke) = tmp(:,2) * RGsqrt(:)
+        MOMY_ (:,ke) = tmp(:,3) * RGsqrt(:)
+        MOMZ_ (:,ke) = tmp(:,4) * RGsqrt(:)
+        DRHOT_(:,ke) = tmp(:,5) * RGsqrt(:)
+      end do    
+
+    else
+
+      !$omp parallel do private( tmp, ii, kk, Mik )
+      do ke=lmesh%NeS, lmesh%NeE
+
+        tmp(:,:) = 0.0_RP
+        do ii=1, elem%Np
+        do kk=1, elem%Np
+          Mik = filter%FilterMat(ii,kk)
+          tmp(ii,1) = tmp(ii,1) + Mik * DDENS_(kk,ke)
+          tmp(ii,2) = tmp(ii,2) + Mik * MOMX_ (kk,ke)
+          tmp(ii,3) = tmp(ii,3) + Mik * MOMY_ (kk,ke)
+          tmp(ii,4) = tmp(ii,4) + Mik * MOMZ_ (kk,ke)
+          tmp(ii,5) = tmp(ii,5) + Mik * DRHOT_(kk,ke)
+        end do
+        end do      
+        DDENS_(:,ke) = tmp(:,1)
+        MOMX_ (:,ke) = tmp(:,2)
+        MOMY_ (:,ke) = tmp(:,3)
+        MOMZ_ (:,ke) = tmp(:,4)
+        DRHOT_(:,ke) = tmp(:,5)
+      end do
+
+    end if
+
+    return
+  end subroutine atm_dyn_dgm_modalfilter_apply
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_tracer_modalfilter_apply(  &
+    QTRC_,                                   & ! (inout)
+    DENS_hyd_, DDENS_,                       & ! (inout)
+    lmesh, elem, filter                      ) ! (in)
+
+    implicit none
+
+    class(LocalMeshBase), intent(in) :: lmesh
+    class(ElementBase), intent(in) :: elem    
+    real(RP), intent(inout)  :: QTRC_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: DENS_hyd_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DDENS_(elem%Np,lmesh%NeA)
+    class(ModalFilter), intent(in) :: filter
+
+    integer :: ke
+    real(RP) :: tmp(elem%Np)
+    integer :: ii, kk
+    real(RP) :: Mik
+
+    real(RP) :: weight(elem%Np)
+    !------------------------------------
+
+    !$omp parallel do private( tmp, ii, kk, Mik, weight )
+    do ke=lmesh%NeS, lmesh%NeE
+
+      tmp(:) = 0.0_RP
+      weight(:) = lmesh%Gsqrt(:,ke) &
+                * ( DENS_hyd_(:,ke) + DDENS_(:,ke) )
+
+      do ii=1, elem%Np
+      do kk=1, elem%Np
+        Mik = filter%FilterMat(ii,kk) * weight(kk)
+
+        tmp(ii) = tmp(ii) + Mik * QTRC_(kk,ke)
+      end do
+      end do
+
+      QTRC_(:,ke) = tmp(:) / weight(:)
+    end do    
+
+    return
+  end subroutine atm_dyn_dgm_tracer_modalfilter_apply
+
+end module scale_atm_dyn_dgm_modalfilter

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune2_p11.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune2_p11.F90
@@ -1,0 +1,256 @@
+!-------------------------------------------------------------------------------
+!> module FElib / Fluid dyn solver / Atmosphere / Common / Modal filter
+!!
+!! @par Description
+!!      Modal filter for Atmospheric dynamical process. 
+!!      The modal filter surpresses the numerical instability due to the aliasing errors. 
+!!
+!! @author Team SCALE
+!<
+!-------------------------------------------------------------------------------
+#include "scaleFElib.h"
+module scale_atm_dyn_dgm_modalfilter
+  !-----------------------------------------------------------------------------
+  !
+  !++ Used modules
+  !
+  use scale_precision
+  use scale_io
+
+  use scale_element_base, only: ElementBase
+  use scale_localmesh_base, only: LocalMeshBase
+  use scale_element_modalfilter, only: ModalFilter
+
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public procedures
+  !
+  public :: atm_dyn_dgm_modalfilter_apply
+  public :: atm_dyn_dgm_tracer_modalfilter_apply
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public parameters & variables
+  !
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedures & variables
+  !
+  !-------------------
+  private :: apply_filter_xyz_direction
+contains
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_modalfilter_apply(  &
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_,     & ! (inout)
+    lmesh, elem, filter, do_weight_Gsqrt     ) ! (in)
+
+    implicit none
+
+    class(LocalMeshBase), intent(in) :: lmesh
+    class(ElementBase), intent(in) :: elem    
+    real(RP), intent(inout)  :: DDENS_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMX_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMY_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMZ_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: DRHOT_(elem%Np,lmesh%NeA)
+    class(ModalFilter), intent(in) :: filter
+    logical, intent(in), optional :: do_weight_Gsqrt
+    
+    integer :: ke
+    real(RP) :: tmp(elem%Np,5)
+    real(RP) :: FilterMat_tr(12,12)
+    integer :: ii, kk
+    real(RP) :: Mik
+    logical :: do_weight_Gsqrt_
+    real(RP) :: RGsqrt(elem%Np)
+    !------------------------------------
+    FilterMat_tr(:,:) = transpose(filter%FilterMat(:,:))
+
+
+    if ( present( do_weight_Gsqrt ) ) then
+      do_weight_Gsqrt_ = do_weight_Gsqrt
+    else
+      do_weight_Gsqrt_ = .false.
+    end if
+
+    if ( do_weight_Gsqrt_ ) then
+      !$omp parallel do private( tmp, ii, kk, Mik, RGsqrt )
+      do ke=lmesh%NeS, lmesh%NeE
+
+        tmp(:,:) = 0.0_RP
+
+        do ii=1, elem%Np
+          DDENS_(ii,ke) = lmesh%Gsqrt(ii,ke) * DDENS_(ii,ke)
+          MOMX_(ii,ke) = lmesh%Gsqrt(ii,ke) * MOMX_(ii,ke)
+          MOMY_(ii,ke) = lmesh%Gsqrt(ii,ke) * MOMY_(ii,ke)
+          MOMZ_(ii,ke) = lmesh%Gsqrt(ii,ke) * MOMZ_(ii,ke)
+          DRHOT_(ii,ke) = lmesh%Gsqrt(ii,ke) * DRHOT_(ii,ke)
+        end do
+
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, DDENS_(:,ke), tmp(:,1))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, MOMX_(:,ke),  tmp(:,2))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, MOMY_(:,ke),  tmp(:,3))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, MOMZ_(:,ke),  tmp(:,4))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, DRHOT_(:,ke), tmp(:,5))
+
+        RGsqrt(:) = 1.0_RP / lmesh%Gsqrt(:,ke)
+        DDENS_(:,ke) = tmp(:,1) * RGsqrt(:)
+        MOMX_ (:,ke) = tmp(:,2) * RGsqrt(:)
+        MOMY_ (:,ke) = tmp(:,3) * RGsqrt(:)
+        MOMZ_ (:,ke) = tmp(:,4) * RGsqrt(:)
+        DRHOT_(:,ke) = tmp(:,5) * RGsqrt(:)
+      end do    
+
+    else
+
+      !$omp parallel do private( tmp, ii, kk, Mik )
+      do ke=lmesh%NeS, lmesh%NeE
+
+        tmp(:,:) = 0.0_RP
+
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, DDENS_(:,ke), tmp(:,1))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, MOMX_(:,ke),  tmp(:,2))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, MOMY_(:,ke),  tmp(:,3))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, MOMZ_(:,ke),  tmp(:,4))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, DRHOT_(:,ke), tmp(:,5))
+
+        DDENS_(:,ke) = tmp(:,1)
+        MOMX_ (:,ke) = tmp(:,2)
+        MOMY_ (:,ke) = tmp(:,3)
+        MOMZ_ (:,ke) = tmp(:,4)
+        DRHOT_(:,ke) = tmp(:,5)
+      end do
+
+    end if
+
+    return
+  end subroutine atm_dyn_dgm_modalfilter_apply
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_tracer_modalfilter_apply(  &
+    QTRC_,                                   & ! (inout)
+    DENS_hyd_, DDENS_,                       & ! (inout)
+    lmesh, elem, filter                      ) ! (in)
+
+    implicit none
+
+    class(LocalMeshBase), intent(in) :: lmesh
+    class(ElementBase), intent(in) :: elem    
+    real(RP), intent(inout)  :: QTRC_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: DENS_hyd_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DDENS_(elem%Np,lmesh%NeA)
+    class(ModalFilter), intent(in) :: filter
+
+    integer :: ke
+    real(RP) :: tmp(elem%Np)
+    integer :: ii, kk
+    real(RP) :: Mik
+
+    real(RP) :: weight(elem%Np)
+    !------------------------------------
+
+    !$omp parallel do private( tmp, ii, kk, Mik, weight )
+    do ke=lmesh%NeS, lmesh%NeE
+
+      tmp(:) = 0.0_RP
+      weight(:) = lmesh%Gsqrt(:,ke) &
+                * ( DENS_hyd_(:,ke) + DDENS_(:,ke) )
+
+      do ii=1, elem%Np
+      do kk=1, elem%Np
+        Mik = filter%FilterMat(ii,kk) * weight(kk)
+
+        tmp(ii) = tmp(ii) + Mik * QTRC_(kk,ke)
+      end do
+      end do
+
+      QTRC_(:,ke) = tmp(:) / weight(:)
+    end do    
+
+    return
+  end subroutine atm_dyn_dgm_tracer_modalfilter_apply
+
+!OCL SERIAL
+  subroutine apply_filter_xyz_direction(filterMat, filterMat_tr, q_in, q_tmp )
+    implicit none
+
+    real(RP), intent(in) :: filterMat(12, 12)
+    real(RP), intent(in) :: filterMat_tr(12, 12)
+    real(RP), intent(inout) :: q_in(12, 12, 12)
+    real(RP), intent(inout) :: q_tmp(12, 12, 12)
+    
+    integer :: i, j, k
+
+    !-- x direction
+    do k=1, 12
+    do j=1, 12
+    do i=1, 12
+
+      q_tmp(i,j,k) = filterMat(i,1)  * q_in(1,j,k) + &
+                     filterMat(i,2)  * q_in(2,j,k) + &
+                     filterMat(i,3)  * q_in(3,j,k) + & 
+                     filterMat(i,4)  * q_in(4,j,k) + & 
+                     filterMat(i,5)  * q_in(5,j,k) + & 
+                     filterMat(i,6)  * q_in(6,j,k) + & 
+                     filterMat(i,7)  * q_in(7,j,k) + & 
+                     filterMat(i,8)  * q_in(8,j,k) + & 
+                     filterMat(i,9)  * q_in(9,j,k) + & 
+                     filterMat(i,10) * q_in(10,j,k) + & 
+                     filterMat(i,11) * q_in(11,j,k) + & 
+                     filterMat(i,12) * q_in(12,j,k)  
+
+    end do
+    end do
+    end do
+
+    !-- y direction
+    do k=1, 12
+    do j=1, 12
+    do i=1, 12
+
+      q_in(i,j,k) = q_tmp(i,1,k)  * filterMat_tr(1,j) + &
+                    q_tmp(i,2,k)  * filterMat_tr(2,j) + &
+                    q_tmp(i,3,k)  * filterMat_tr(3,j) + &
+                    q_tmp(i,4,k)  * filterMat_tr(4,j) + &
+                    q_tmp(i,5,k)  * filterMat_tr(5,j) + &
+                    q_tmp(i,6,k)  * filterMat_tr(6,j) + &
+                    q_tmp(i,7,k)  * filterMat_tr(7,j) + &
+                    q_tmp(i,8,k)  * filterMat_tr(8,j) + &
+                    q_tmp(i,9,k)  * filterMat_tr(9,j) + &
+                    q_tmp(i,10,k) * filterMat_tr(10,j) + &
+                    q_tmp(i,11,k) * filterMat_tr(11,j) + &
+                    q_tmp(i,12,k) * filterMat_tr(12,j) 
+
+    end do
+    end do
+    end do
+
+    !-- z direction
+    do k=1, 12
+    do j=1, 12
+    do i=1, 12
+
+      q_tmp(i,j,k) = q_in(i,j,1)  * filterMat_tr(1,k) + &
+                     q_in(i,j,2)  * filterMat_tr(2,k) + &
+                     q_in(i,j,3)  * filterMat_tr(3,k) + &
+                     q_in(i,j,4)  * filterMat_tr(4,k) + &
+                     q_in(i,j,5)  * filterMat_tr(5,k) + &
+                     q_in(i,j,6)  * filterMat_tr(6,k) + &
+                     q_in(i,j,7)  * filterMat_tr(7,k) + &
+                     q_in(i,j,8)  * filterMat_tr(8,k) + &
+                     q_in(i,j,9)  * filterMat_tr(9,k) + &
+                     q_in(i,j,10) * filterMat_tr(10,k) + &
+                     q_in(i,j,11) * filterMat_tr(11,k) + &
+                     q_in(i,j,12) * filterMat_tr(12,k) 
+
+    end do
+    end do
+    end do
+  end subroutine apply_filter_xyz_direction
+
+end module scale_atm_dyn_dgm_modalfilter

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune3_p11.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune3_p11.F90
@@ -184,7 +184,7 @@ contains
     real(RP), intent(inout) :: q_in(12, 12, 12)
     real(RP), intent(inout) :: q_tmp(12, 12, 12)
     
-    real(RP) :: tmp1, tmp2
+    real(RP) :: tmp1, tmp2, tmp3
     integer :: i, j, k
 
     !-- x direction
@@ -195,18 +195,19 @@ contains
       tmp1 = filterMat(i,1)  * q_in(1,j,k) + &
              filterMat(i,2)  * q_in(2,j,k) + &
              filterMat(i,3)  * q_in(3,j,k) + & 
-             filterMat(i,4)  * q_in(4,j,k) + & 
-             filterMat(i,5)  * q_in(5,j,k) + & 
+             filterMat(i,4)  * q_in(4,j,k)
+              
+      tmp2 = filterMat(i,5)  * q_in(5,j,k) + & 
              filterMat(i,6)  * q_in(6,j,k) + & 
              filterMat(i,7)  * q_in(7,j,k) + & 
              filterMat(i,8)  * q_in(8,j,k) 
 
-      tmp2 = filterMat(i,9)  * q_in(9,j,k) + & 
+      tmp3 = filterMat(i,9)  * q_in(9,j,k) + & 
              filterMat(i,10) * q_in(10,j,k) + & 
              filterMat(i,11) * q_in(11,j,k) + & 
              filterMat(i,12) * q_in(12,j,k)  
 
-      q_tmp(i,j,k) = tmp1 + tmp2
+      q_tmp(i,j,k) = tmp1 + tmp2 + tmp3
 
     end do
     end do
@@ -220,18 +221,19 @@ contains
       tmp1 = q_tmp(i,1,k)  * filterMat_tr(1,j) + &
              q_tmp(i,2,k)  * filterMat_tr(2,j) + &
              q_tmp(i,3,k)  * filterMat_tr(3,j) + &
-             q_tmp(i,4,k)  * filterMat_tr(4,j) + &
-             q_tmp(i,5,k)  * filterMat_tr(5,j) + &
+             q_tmp(i,4,k)  * filterMat_tr(4,j)
+
+      tmp2 = q_tmp(i,5,k)  * filterMat_tr(5,j) + &
              q_tmp(i,6,k)  * filterMat_tr(6,j) + &
              q_tmp(i,7,k)  * filterMat_tr(7,j) + &
              q_tmp(i,8,k)  * filterMat_tr(8,j)
 
-      tmp2 = q_tmp(i,9,k)  * filterMat_tr(9,j) + &
+      tmp3 = q_tmp(i,9,k)  * filterMat_tr(9,j) + &
              q_tmp(i,10,k) * filterMat_tr(10,j) + &
              q_tmp(i,11,k) * filterMat_tr(11,j) + &
              q_tmp(i,12,k) * filterMat_tr(12,j) 
 
-      q_in(i,j,k) = tmp1 + tmp2
+      q_in(i,j,k) = tmp1 + tmp2 + tmp3
 
     end do
     end do
@@ -245,18 +247,19 @@ contains
       tmp1 = q_in(i,j,1)  * filterMat_tr(1,k) + &
              q_in(i,j,2)  * filterMat_tr(2,k) + &
              q_in(i,j,3)  * filterMat_tr(3,k) + &
-             q_in(i,j,4)  * filterMat_tr(4,k) + &
-             q_in(i,j,5)  * filterMat_tr(5,k) + &
+             q_in(i,j,4)  * filterMat_tr(4,k)
+
+      tmp2 = q_in(i,j,5)  * filterMat_tr(5,k) + &
              q_in(i,j,6)  * filterMat_tr(6,k) + &
              q_in(i,j,7)  * filterMat_tr(7,k) + &
              q_in(i,j,8)  * filterMat_tr(8,k)
 
-      tmp2 = q_in(i,j,9)  * filterMat_tr(9,k) + &
+      tmp3 = q_in(i,j,9)  * filterMat_tr(9,k) + &
              q_in(i,j,10) * filterMat_tr(10,k) + &
              q_in(i,j,11) * filterMat_tr(11,k) + &
              q_in(i,j,12) * filterMat_tr(12,k) 
 
-      q_tmp(i,j,k) = tmp1 + tmp2
+      q_tmp(i,j,k) = tmp1 + tmp2 + tmp3
 
     end do
     end do

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune3_p11.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune3_p11.F90
@@ -1,0 +1,266 @@
+!-------------------------------------------------------------------------------
+!> module FElib / Fluid dyn solver / Atmosphere / Common / Modal filter
+!!
+!! @par Description
+!!      Modal filter for Atmospheric dynamical process. 
+!!      The modal filter surpresses the numerical instability due to the aliasing errors. 
+!!
+!! @author Team SCALE
+!<
+!-------------------------------------------------------------------------------
+#include "scaleFElib.h"
+module scale_atm_dyn_dgm_modalfilter
+  !-----------------------------------------------------------------------------
+  !
+  !++ Used modules
+  !
+  use scale_precision
+  use scale_io
+
+  use scale_element_base, only: ElementBase
+  use scale_localmesh_base, only: LocalMeshBase
+  use scale_element_modalfilter, only: ModalFilter
+
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public procedures
+  !
+  public :: atm_dyn_dgm_modalfilter_apply
+  public :: atm_dyn_dgm_tracer_modalfilter_apply
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public parameters & variables
+  !
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedures & variables
+  !
+  !-------------------
+  private :: apply_filter_xyz_direction
+contains
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_modalfilter_apply(  &
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_,     & ! (inout)
+    lmesh, elem, filter, do_weight_Gsqrt     ) ! (in)
+
+    implicit none
+
+    class(LocalMeshBase), intent(in) :: lmesh
+    class(ElementBase), intent(in) :: elem    
+    real(RP), intent(inout)  :: DDENS_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMX_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMY_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMZ_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: DRHOT_(elem%Np,lmesh%NeA)
+    class(ModalFilter), intent(in) :: filter
+    logical, intent(in), optional :: do_weight_Gsqrt
+    
+    integer :: ke
+    real(RP) :: tmp(elem%Np,5)
+    real(RP) :: FilterMat_tr(12,12)
+    integer :: ii, kk
+    real(RP) :: Mik
+    logical :: do_weight_Gsqrt_
+    real(RP) :: RGsqrt(elem%Np)
+    !------------------------------------
+    FilterMat_tr(:,:) = transpose(filter%FilterMat(:,:))
+
+
+    if ( present( do_weight_Gsqrt ) ) then
+      do_weight_Gsqrt_ = do_weight_Gsqrt
+    else
+      do_weight_Gsqrt_ = .false.
+    end if
+
+    if ( do_weight_Gsqrt_ ) then
+      !$omp parallel do private( tmp, ii, kk, Mik, RGsqrt )
+      do ke=lmesh%NeS, lmesh%NeE
+
+        tmp(:,:) = 0.0_RP
+
+        do ii=1, elem%Np
+          DDENS_(ii,ke) = lmesh%Gsqrt(ii,ke) * DDENS_(ii,ke)
+          MOMX_(ii,ke) = lmesh%Gsqrt(ii,ke) * MOMX_(ii,ke)
+          MOMY_(ii,ke) = lmesh%Gsqrt(ii,ke) * MOMY_(ii,ke)
+          MOMZ_(ii,ke) = lmesh%Gsqrt(ii,ke) * MOMZ_(ii,ke)
+          DRHOT_(ii,ke) = lmesh%Gsqrt(ii,ke) * DRHOT_(ii,ke)
+        end do
+
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, DDENS_(:,ke), tmp(:,1))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, MOMX_(:,ke),  tmp(:,2))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, MOMY_(:,ke),  tmp(:,3))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, MOMZ_(:,ke),  tmp(:,4))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, DRHOT_(:,ke), tmp(:,5))
+
+        RGsqrt(:) = 1.0_RP / lmesh%Gsqrt(:,ke)
+        DDENS_(:,ke) = tmp(:,1) * RGsqrt(:)
+        MOMX_ (:,ke) = tmp(:,2) * RGsqrt(:)
+        MOMY_ (:,ke) = tmp(:,3) * RGsqrt(:)
+        MOMZ_ (:,ke) = tmp(:,4) * RGsqrt(:)
+        DRHOT_(:,ke) = tmp(:,5) * RGsqrt(:)
+      end do    
+
+    else
+
+      !$omp parallel do private( tmp, ii, kk, Mik )
+      do ke=lmesh%NeS, lmesh%NeE
+
+        tmp(:,:) = 0.0_RP
+
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, DDENS_(:,ke), tmp(:,1))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, MOMX_(:,ke),  tmp(:,2))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, MOMY_(:,ke),  tmp(:,3))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, MOMZ_(:,ke),  tmp(:,4))
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, DRHOT_(:,ke), tmp(:,5))
+
+        DDENS_(:,ke) = tmp(:,1)
+        MOMX_ (:,ke) = tmp(:,2)
+        MOMY_ (:,ke) = tmp(:,3)
+        MOMZ_ (:,ke) = tmp(:,4)
+        DRHOT_(:,ke) = tmp(:,5)
+      end do
+
+    end if
+
+    return
+  end subroutine atm_dyn_dgm_modalfilter_apply
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_tracer_modalfilter_apply(  &
+    QTRC_,                                   & ! (inout)
+    DENS_hyd_, DDENS_,                       & ! (inout)
+    lmesh, elem, filter                      ) ! (in)
+
+    implicit none
+
+    class(LocalMeshBase), intent(in) :: lmesh
+    class(ElementBase), intent(in) :: elem    
+    real(RP), intent(inout)  :: QTRC_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: DENS_hyd_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DDENS_(elem%Np,lmesh%NeA)
+    class(ModalFilter), intent(in) :: filter
+
+    integer :: ke
+    real(RP) :: tmp(elem%Np)
+    integer :: ii, kk
+    real(RP) :: Mik
+
+    real(RP) :: weight(elem%Np)
+    !------------------------------------
+
+    !$omp parallel do private( tmp, ii, kk, Mik, weight )
+    do ke=lmesh%NeS, lmesh%NeE
+
+      tmp(:) = 0.0_RP
+      weight(:) = lmesh%Gsqrt(:,ke) &
+                * ( DENS_hyd_(:,ke) + DDENS_(:,ke) )
+
+      do ii=1, elem%Np
+      do kk=1, elem%Np
+        Mik = filter%FilterMat(ii,kk) * weight(kk)
+
+        tmp(ii) = tmp(ii) + Mik * QTRC_(kk,ke)
+      end do
+      end do
+
+      QTRC_(:,ke) = tmp(:) / weight(:)
+    end do    
+
+    return
+  end subroutine atm_dyn_dgm_tracer_modalfilter_apply
+
+!OCL SERIAL
+  subroutine apply_filter_xyz_direction(filterMat, filterMat_tr, q_in, q_tmp )
+    implicit none
+
+    real(RP), intent(in) :: filterMat(12, 12)
+    real(RP), intent(in) :: filterMat_tr(12, 12)
+    real(RP), intent(inout) :: q_in(12, 12, 12)
+    real(RP), intent(inout) :: q_tmp(12, 12, 12)
+    
+    real(RP) :: tmp1, tmp2
+    integer :: i, j, k
+
+    !-- x direction
+    do k=1, 12
+    do j=1, 12
+    do i=1, 12
+
+      tmp1 = filterMat(i,1)  * q_in(1,j,k) + &
+             filterMat(i,2)  * q_in(2,j,k) + &
+             filterMat(i,3)  * q_in(3,j,k) + & 
+             filterMat(i,4)  * q_in(4,j,k) + & 
+             filterMat(i,5)  * q_in(5,j,k) + & 
+             filterMat(i,6)  * q_in(6,j,k) + & 
+             filterMat(i,7)  * q_in(7,j,k) + & 
+             filterMat(i,8)  * q_in(8,j,k) 
+
+      tmp2 = filterMat(i,9)  * q_in(9,j,k) + & 
+             filterMat(i,10) * q_in(10,j,k) + & 
+             filterMat(i,11) * q_in(11,j,k) + & 
+             filterMat(i,12) * q_in(12,j,k)  
+
+      q_tmp(i,j,k) = tmp1 + tmp2
+
+    end do
+    end do
+    end do
+
+    !-- y direction
+    do k=1, 12
+    do j=1, 12
+    do i=1, 12
+
+      tmp1 = q_tmp(i,1,k)  * filterMat_tr(1,j) + &
+             q_tmp(i,2,k)  * filterMat_tr(2,j) + &
+             q_tmp(i,3,k)  * filterMat_tr(3,j) + &
+             q_tmp(i,4,k)  * filterMat_tr(4,j) + &
+             q_tmp(i,5,k)  * filterMat_tr(5,j) + &
+             q_tmp(i,6,k)  * filterMat_tr(6,j) + &
+             q_tmp(i,7,k)  * filterMat_tr(7,j) + &
+             q_tmp(i,8,k)  * filterMat_tr(8,j)
+
+      tmp2 = q_tmp(i,9,k)  * filterMat_tr(9,j) + &
+             q_tmp(i,10,k) * filterMat_tr(10,j) + &
+             q_tmp(i,11,k) * filterMat_tr(11,j) + &
+             q_tmp(i,12,k) * filterMat_tr(12,j) 
+
+      q_in(i,j,k) = tmp1 + tmp2
+
+    end do
+    end do
+    end do
+
+    !-- z direction
+    do k=1, 12
+    do j=1, 12
+    do i=1, 12
+
+      tmp1 = q_in(i,j,1)  * filterMat_tr(1,k) + &
+             q_in(i,j,2)  * filterMat_tr(2,k) + &
+             q_in(i,j,3)  * filterMat_tr(3,k) + &
+             q_in(i,j,4)  * filterMat_tr(4,k) + &
+             q_in(i,j,5)  * filterMat_tr(5,k) + &
+             q_in(i,j,6)  * filterMat_tr(6,k) + &
+             q_in(i,j,7)  * filterMat_tr(7,k) + &
+             q_in(i,j,8)  * filterMat_tr(8,k) + &
+
+      tmp2 = q_in(i,j,9)  * filterMat_tr(9,k) + &
+             q_in(i,j,10) * filterMat_tr(10,k) + &
+             q_in(i,j,11) * filterMat_tr(11,k) + &
+             q_in(i,j,12) * filterMat_tr(12,k) 
+
+      q_tmp(i,j,k) = tmp1 + tmp2
+
+    end do
+    end do
+    end do
+  end subroutine apply_filter_xyz_direction
+
+end module scale_atm_dyn_dgm_modalfilter

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune3_p11.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune3_p11.F90
@@ -249,7 +249,7 @@ contains
              q_in(i,j,5)  * filterMat_tr(5,k) + &
              q_in(i,j,6)  * filterMat_tr(6,k) + &
              q_in(i,j,7)  * filterMat_tr(7,k) + &
-             q_in(i,j,8)  * filterMat_tr(8,k) + &
+             q_in(i,j,8)  * filterMat_tr(8,k)
 
       tmp2 = q_in(i,j,9)  * filterMat_tr(9,k) + &
              q_in(i,j,10) * filterMat_tr(10,k) + &

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune_p11.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune_p11.F90
@@ -1,0 +1,427 @@
+!-------------------------------------------------------------------------------
+!> module FElib / Fluid dyn solver / Atmosphere / Common / Modal filter
+!!
+!! @par Description
+!!      Modal filter for Atmospheric dynamical process. 
+!!      The modal filter surpresses the numerical instability due to the aliasing errors. 
+!!
+!! @author Team SCALE
+!<
+!-------------------------------------------------------------------------------
+#include "scaleFElib.h"
+module scale_atm_dyn_dgm_modalfilter
+  !-----------------------------------------------------------------------------
+  !
+  !++ Used modules
+  !
+  use scale_precision
+  use scale_io
+
+  use scale_element_base, only: ElementBase
+  use scale_localmesh_base, only: LocalMeshBase
+  use scale_element_modalfilter, only: ModalFilter
+
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public procedures
+  !
+  public :: atm_dyn_dgm_modalfilter_apply
+  public :: atm_dyn_dgm_tracer_modalfilter_apply
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public parameters & variables
+  !
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedures & variables
+  !
+  !-------------------
+  private :: apply_filter_xyz_direction
+contains
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_modalfilter_apply(  &
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_,     & ! (inout)
+    lmesh, elem, filter, do_weight_Gsqrt     ) ! (in)
+
+    implicit none
+
+    class(LocalMeshBase), intent(in) :: lmesh
+    class(ElementBase), intent(in) :: elem    
+    real(RP), intent(inout)  :: DDENS_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMX_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMY_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMZ_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: DRHOT_(elem%Np,lmesh%NeA)
+    class(ModalFilter), intent(in) :: filter
+    logical, intent(in), optional :: do_weight_Gsqrt
+    
+    integer :: ke
+    real(RP) :: tmp(elem%Np,5)
+    real(RP) :: FilterMat_tr(12,12)
+    integer :: ii, kk
+    real(RP) :: Mik
+    logical :: do_weight_Gsqrt_
+    real(RP) :: RGsqrt(elem%Np)
+    !------------------------------------
+    FilterMat_tr(:,:) = transpose(filter%FilterMat(:,:))
+
+
+    if ( present( do_weight_Gsqrt ) ) then
+      do_weight_Gsqrt_ = do_weight_Gsqrt
+    else
+      do_weight_Gsqrt_ = .false.
+    end if
+
+    if ( do_weight_Gsqrt_ ) then
+      !$omp parallel do private( tmp, ii, kk, Mik, RGsqrt )
+      do ke=lmesh%NeS, lmesh%NeE
+
+        tmp(:,:) = 0.0_RP
+        !do ii=1, elem%Np
+        !do kk=1, elem%Np
+        !  Mik = filter%FilterMat(ii,kk) * lmesh%Gsqrt(kk,ke)
+
+        !  tmp(ii,1) = tmp(ii,1) + Mik * DDENS_(kk,ke)
+        !  tmp(ii,2) = tmp(ii,2) + Mik * MOMX_ (kk,ke)
+        !  tmp(ii,3) = tmp(ii,3) + Mik * MOMY_ (kk,ke)
+        !  tmp(ii,4) = tmp(ii,4) + Mik * MOMZ_ (kk,ke)
+        !  tmp(ii,5) = tmp(ii,5) + Mik * DRHOT_(kk,ke)
+        !end do
+        !end do
+
+        do ii=1, elem%Np
+          DDENS_(ii,ke) = lmesh%Gsqrt(ii,ke) * DDENS_(ii,ke)
+          MOMX_(ii,ke) = lmesh%Gsqrt(ii,ke) * MOMX_(ii,ke)
+          MOMY_(ii,ke) = lmesh%Gsqrt(ii,ke) * MOMY_(ii,ke)
+          MOMZ_(ii,ke) = lmesh%Gsqrt(ii,ke) * MOMZ_(ii,ke)
+          DRHOT_(ii,ke) = lmesh%Gsqrt(ii,ke) * DRHOT_(ii,ke)
+        end do
+
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, DDENS_(:,ke), MOMX_(:,ke), MOMY_(:,ke), MOMZ_(:,ke), DRHOT_(:,ke), tmp)
+
+        RGsqrt(:) = 1.0_RP / lmesh%Gsqrt(:,ke)
+        DDENS_(:,ke) = tmp(:,1) * RGsqrt(:)
+        MOMX_ (:,ke) = tmp(:,2) * RGsqrt(:)
+        MOMY_ (:,ke) = tmp(:,3) * RGsqrt(:)
+        MOMZ_ (:,ke) = tmp(:,4) * RGsqrt(:)
+        DRHOT_(:,ke) = tmp(:,5) * RGsqrt(:)
+      end do    
+
+    else
+
+      !$omp parallel do private( tmp, ii, kk, Mik )
+      do ke=lmesh%NeS, lmesh%NeE
+
+        tmp(:,:) = 0.0_RP
+        !do ii=1, elem%Np
+        !do kk=1, elem%Np
+        !  Mik = filter%FilterMat(ii,kk)
+        !  tmp(ii,1) = tmp(ii,1) + Mik * DDENS_(kk,ke)
+        !  tmp(ii,2) = tmp(ii,2) + Mik * MOMX_ (kk,ke)
+        !  tmp(ii,3) = tmp(ii,3) + Mik * MOMY_ (kk,ke)
+        !  tmp(ii,4) = tmp(ii,4) + Mik * MOMZ_ (kk,ke)
+        !  tmp(ii,5) = tmp(ii,5) + Mik * DRHOT_(kk,ke)
+        !end do
+        !end do      
+
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, DDENS_(:,ke), MOMX_(:,ke), MOMY_(:,ke), MOMZ_(:,ke), DRHOT_(:,ke), tmp)
+
+        DDENS_(:,ke) = tmp(:,1)
+        MOMX_ (:,ke) = tmp(:,2)
+        MOMY_ (:,ke) = tmp(:,3)
+        MOMZ_ (:,ke) = tmp(:,4)
+        DRHOT_(:,ke) = tmp(:,5)
+      end do
+
+    end if
+
+    return
+  end subroutine atm_dyn_dgm_modalfilter_apply
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_tracer_modalfilter_apply(  &
+    QTRC_,                                   & ! (inout)
+    DENS_hyd_, DDENS_,                       & ! (inout)
+    lmesh, elem, filter                      ) ! (in)
+
+    implicit none
+
+    class(LocalMeshBase), intent(in) :: lmesh
+    class(ElementBase), intent(in) :: elem    
+    real(RP), intent(inout)  :: QTRC_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: DENS_hyd_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DDENS_(elem%Np,lmesh%NeA)
+    class(ModalFilter), intent(in) :: filter
+
+    integer :: ke
+    real(RP) :: tmp(elem%Np)
+    integer :: ii, kk
+    real(RP) :: Mik
+
+    real(RP) :: weight(elem%Np)
+    !------------------------------------
+
+    !$omp parallel do private( tmp, ii, kk, Mik, weight )
+    do ke=lmesh%NeS, lmesh%NeE
+
+      tmp(:) = 0.0_RP
+      weight(:) = lmesh%Gsqrt(:,ke) &
+                * ( DENS_hyd_(:,ke) + DDENS_(:,ke) )
+
+      do ii=1, elem%Np
+      do kk=1, elem%Np
+        Mik = filter%FilterMat(ii,kk) * weight(kk)
+
+        tmp(ii) = tmp(ii) + Mik * QTRC_(kk,ke)
+      end do
+      end do
+
+      QTRC_(:,ke) = tmp(:) / weight(:)
+    end do    
+
+    return
+  end subroutine atm_dyn_dgm_tracer_modalfilter_apply
+
+!OCL SERIAL
+  subroutine apply_filter_xyz_direction(filterMat, filterMat_tr, DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, tmp )
+    implicit none
+
+    real(RP), intent(in) :: filterMat(12, 12)
+    real(RP), intent(in) :: filterMat_tr(12, 12)
+    real(RP), intent(inout) :: DDENS_(12, 12, 12)
+    real(RP), intent(inout) :: MOMX_(12, 12, 12)
+    real(RP), intent(inout) :: MOMY_(12, 12, 12)
+    real(RP), intent(inout) :: MOMZ_(12, 12, 12)
+    real(RP), intent(inout) :: DRHOT_(12, 12, 12)
+    real(RP), intent(inout) :: tmp(12, 12, 12, 5)
+    
+    integer :: i, j, k
+
+    !-- x direction
+    do k=1, 12
+    do j=1, 12
+    do i=1, 12
+
+      tmp(i,j,k,1) = filterMat(i,1) * DDENS_(1,j,k) + &
+                     filterMat(i,2) * DDENS_(2,j,k) + &
+                     filterMat(i,3) * DDENS_(3,j,k) + & 
+                     filterMat(i,4) * DDENS_(4,j,k) + & 
+                     filterMat(i,5) * DDENS_(5,j,k) + & 
+                     filterMat(i,6) * DDENS_(6,j,k) + & 
+                     filterMat(i,7) * DDENS_(7,j,k) + & 
+                     filterMat(i,8) * DDENS_(8,j,k) + & 
+                     filterMat(i,9) * DDENS_(9,j,k) + & 
+                     filterMat(i,10) * DDENS_(10,j,k) + & 
+                     filterMat(i,11) * DDENS_(11,j,k) + & 
+                     filterMat(i,12) * DDENS_(12,j,k)  
+
+      tmp(i,j,k,2) = filterMat(i,1) * MOMX_(1,j,k) + &
+                     filterMat(i,2) * MOMX_(2,j,k) + &
+                     filterMat(i,3) * MOMX_(3,j,k) + & 
+                     filterMat(i,4) * MOMX_(4,j,k) + & 
+                     filterMat(i,5) * MOMX_(5,j,k) + & 
+                     filterMat(i,6) * MOMX_(6,j,k) + & 
+                     filterMat(i,7) * MOMX_(7,j,k) + & 
+                     filterMat(i,8) * MOMX_(8,j,k) + & 
+                     filterMat(i,9) * MOMX_(9,j,k) + & 
+                     filterMat(i,10) * MOMX_(10,j,k) + & 
+                     filterMat(i,11) * MOMX_(11,j,k) + & 
+                     filterMat(i,12) * MOMX_(12,j,k)  
+
+      tmp(i,j,k,3) = filterMat(i,1) * MOMY_(1,j,k) + &
+                     filterMat(i,2) * MOMY_(2,j,k) + &
+                     filterMat(i,3) * MOMY_(3,j,k) + & 
+                     filterMat(i,4) * MOMY_(4,j,k) + & 
+                     filterMat(i,5) * MOMY_(5,j,k) + & 
+                     filterMat(i,6) * MOMY_(6,j,k) + & 
+                     filterMat(i,7) * MOMY_(7,j,k) + & 
+                     filterMat(i,8) * MOMY_(8,j,k) + & 
+                     filterMat(i,9) * MOMY_(9,j,k) + & 
+                     filterMat(i,10) * MOMY_(10,j,k) + & 
+                     filterMat(i,11) * MOMY_(11,j,k) + & 
+                     filterMat(i,12) * MOMY_(12,j,k)  
+
+      tmp(i,j,k,4) = filterMat(i,1) * MOMZ_(1,j,k) + &
+                     filterMat(i,2) * MOMZ_(2,j,k) + &
+                     filterMat(i,3) * MOMZ_(3,j,k) + & 
+                     filterMat(i,4) * MOMZ_(4,j,k) + & 
+                     filterMat(i,5) * MOMZ_(5,j,k) + & 
+                     filterMat(i,6) * MOMZ_(6,j,k) + & 
+                     filterMat(i,7) * MOMZ_(7,j,k) + & 
+                     filterMat(i,8) * MOMZ_(8,j,k) + & 
+                     filterMat(i,9) * MOMZ_(9,j,k) + & 
+                     filterMat(i,10) * MOMZ_(10,j,k) + & 
+                     filterMat(i,11) * MOMZ_(11,j,k) + & 
+                     filterMat(i,12) * MOMZ_(12,j,k)  
+
+      tmp(i,j,k,5) = filterMat(i,1) * DRHOT_(1,j,k) + &
+                     filterMat(i,2) * DRHOT_(2,j,k) + &
+                     filterMat(i,3) * DRHOT_(3,j,k) + & 
+                     filterMat(i,4) * DRHOT_(4,j,k) + & 
+                     filterMat(i,5) * DRHOT_(5,j,k) + & 
+                     filterMat(i,6) * DRHOT_(6,j,k) + & 
+                     filterMat(i,7) * DRHOT_(7,j,k) + & 
+                     filterMat(i,8) * DRHOT_(8,j,k) + & 
+                     filterMat(i,9) * DRHOT_(9,j,k) + & 
+                     filterMat(i,10) * DRHOT_(10,j,k) + & 
+                     filterMat(i,11) * DRHOT_(11,j,k) + & 
+                     filterMat(i,12) * DRHOT_(12,j,k)  
+
+    end do
+    end do
+    end do
+
+    !-- y direction
+    do k=1, 12
+    do j=1, 12
+    do i=1, 12
+      DDENS_(i,j,k) = tmp(i,1,k,1) * filterMat_tr(1,j) + &
+                      tmp(i,2,k,1) * filterMat_tr(2,j) + &
+                      tmp(i,3,k,1) * filterMat_tr(3,j) + &
+                      tmp(i,4,k,1) * filterMat_tr(4,j) + &
+                      tmp(i,5,k,1) * filterMat_tr(5,j) + &
+                      tmp(i,6,k,1) * filterMat_tr(6,j) + &
+                      tmp(i,7,k,1) * filterMat_tr(7,j) + &
+                      tmp(i,8,k,1) * filterMat_tr(8,j) + &
+                      tmp(i,9,k,1) * filterMat_tr(9,j) + &
+                      tmp(i,10,k,1) * filterMat_tr(10,j) + &
+                      tmp(i,11,k,1) * filterMat_tr(11,j) + &
+                      tmp(i,12,k,1) * filterMat_tr(12,j) 
+
+      MOMX_(i,j,k) = tmp(i,1,k,2) * filterMat_tr(1,j) + &
+                     tmp(i,2,k,2) * filterMat_tr(2,j) + &
+                     tmp(i,3,k,2) * filterMat_tr(3,j) + &
+                     tmp(i,4,k,2) * filterMat_tr(4,j) + &
+                     tmp(i,5,k,2) * filterMat_tr(5,j) + &
+                     tmp(i,6,k,2) * filterMat_tr(6,j) + &
+                     tmp(i,7,k,2) * filterMat_tr(7,j) + &
+                     tmp(i,8,k,2) * filterMat_tr(8,j) + &
+                     tmp(i,9,k,2) * filterMat_tr(9,j) + &
+                     tmp(i,10,k,2) * filterMat_tr(10,j) + &
+                     tmp(i,11,k,2) * filterMat_tr(11,j) + &
+                     tmp(i,12,k,2) * filterMat_tr(12,j) 
+
+      MOMY_(i,j,k) = tmp(i,1,k,3) * filterMat_tr(1,j) + &
+                     tmp(i,2,k,3) * filterMat_tr(2,j) + &
+                     tmp(i,3,k,3) * filterMat_tr(3,j) + &
+                     tmp(i,4,k,3) * filterMat_tr(4,j) + &
+                     tmp(i,5,k,3) * filterMat_tr(5,j) + &
+                     tmp(i,6,k,3) * filterMat_tr(6,j) + &
+                     tmp(i,7,k,3) * filterMat_tr(7,j) + &
+                     tmp(i,8,k,3) * filterMat_tr(8,j) + &
+                     tmp(i,9,k,3) * filterMat_tr(9,j) + &
+                     tmp(i,10,k,3) * filterMat_tr(10,j) + &
+                     tmp(i,11,k,3) * filterMat_tr(11,j) + &
+                     tmp(i,12,k,3) * filterMat_tr(12,j) 
+
+      MOMZ_(i,j,k) = tmp(i,1,k,4) * filterMat_tr(1,j) + &
+                     tmp(i,2,k,4) * filterMat_tr(2,j) + &
+                     tmp(i,3,k,4) * filterMat_tr(3,j) + &
+                     tmp(i,4,k,4) * filterMat_tr(4,j) + &
+                     tmp(i,5,k,4) * filterMat_tr(5,j) + &
+                     tmp(i,6,k,4) * filterMat_tr(6,j) + &
+                     tmp(i,7,k,4) * filterMat_tr(7,j) + &
+                     tmp(i,8,k,4) * filterMat_tr(8,j) + &
+                     tmp(i,9,k,4) * filterMat_tr(9,j) + &
+                     tmp(i,10,k,4) * filterMat_tr(10,j) + &
+                     tmp(i,11,k,4) * filterMat_tr(11,j) + &
+                     tmp(i,12,k,4) * filterMat_tr(12,j) 
+
+      DRHOT_(i,j,k) = tmp(i,1,k,5) * filterMat_tr(1,j) + &
+                      tmp(i,2,k,5) * filterMat_tr(2,j) + &
+                      tmp(i,3,k,5) * filterMat_tr(3,j) + &
+                      tmp(i,4,k,5) * filterMat_tr(4,j) + &
+                      tmp(i,5,k,5) * filterMat_tr(5,j) + &
+                      tmp(i,6,k,5) * filterMat_tr(6,j) + &
+                      tmp(i,7,k,5) * filterMat_tr(7,j) + &
+                      tmp(i,8,k,5) * filterMat_tr(8,j) + &
+                      tmp(i,9,k,5) * filterMat_tr(9,j) + &
+                      tmp(i,10,k,5) * filterMat_tr(10,j) + &
+                      tmp(i,11,k,5) * filterMat_tr(11,j) + &
+                      tmp(i,12,k,5) * filterMat_tr(12,j) 
+
+    end do
+    end do
+    end do
+
+    !-- z direction
+    do k=1, 12
+    do j=1, 12
+    do i=1, 12
+      tmp(i,j,k,1) = DDENS_(i,j,1) * filterMat_tr(1,k) + &
+                     DDENS_(i,j,2) * filterMat_tr(2,k) + &
+                     DDENS_(i,j,3) * filterMat_tr(3,k) + &
+                     DDENS_(i,j,4) * filterMat_tr(4,k) + &
+                     DDENS_(i,j,5) * filterMat_tr(5,k) + &
+                     DDENS_(i,j,6) * filterMat_tr(6,k) + &
+                     DDENS_(i,j,7) * filterMat_tr(7,k) + &
+                     DDENS_(i,j,8) * filterMat_tr(8,k) + &
+                     DDENS_(i,j,9) * filterMat_tr(9,k) + &
+                     DDENS_(i,j,10) * filterMat_tr(10,k) + &
+                     DDENS_(i,j,11) * filterMat_tr(11,k) + &
+                     DDENS_(i,j,12) * filterMat_tr(12,k) 
+
+      tmp(i,j,k,2) = MOMX_(i,j,1) * filterMat_tr(1,k) + &
+                     MOMX_(i,j,2) * filterMat_tr(2,k) + &
+                     MOMX_(i,j,3) * filterMat_tr(3,k) + &
+                     MOMX_(i,j,4) * filterMat_tr(4,k) + &
+                     MOMX_(i,j,5) * filterMat_tr(5,k) + &
+                     MOMX_(i,j,6) * filterMat_tr(6,k) + &
+                     MOMX_(i,j,7) * filterMat_tr(7,k) + &
+                     MOMX_(i,j,8) * filterMat_tr(8,k) + &
+                     MOMX_(i,j,9) * filterMat_tr(9,k) + &
+                     MOMX_(i,j,10) * filterMat_tr(10,k) + &
+                     MOMX_(i,j,11) * filterMat_tr(11,k) + &
+                     MOMX_(i,j,12) * filterMat_tr(12,k) 
+
+      tmp(i,j,k,3) = MOMY_(i,j,1) * filterMat_tr(1,k) + &
+                     MOMY_(i,j,2) * filterMat_tr(2,k) + &
+                     MOMY_(i,j,3) * filterMat_tr(3,k) + &
+                     MOMY_(i,j,4) * filterMat_tr(4,k) + &
+                     MOMY_(i,j,5) * filterMat_tr(5,k) + &
+                     MOMY_(i,j,6) * filterMat_tr(6,k) + &
+                     MOMY_(i,j,7) * filterMat_tr(7,k) + &
+                     MOMY_(i,j,8) * filterMat_tr(8,k) + &
+                     MOMY_(i,j,9) * filterMat_tr(9,k) + &
+                     MOMY_(i,j,10) * filterMat_tr(10,k) + &
+                     MOMY_(i,j,11) * filterMat_tr(11,k) + &
+                     MOMY_(i,j,12) * filterMat_tr(12,k) 
+
+      tmp(i,j,k,4) = MOMZ_(i,j,1) * filterMat_tr(1,k) + &
+                     MOMZ_(i,j,2) * filterMat_tr(2,k) + &
+                     MOMZ_(i,j,3) * filterMat_tr(3,k) + &
+                     MOMZ_(i,j,4) * filterMat_tr(4,k) + &
+                     MOMZ_(i,j,5) * filterMat_tr(5,k) + &
+                     MOMZ_(i,j,6) * filterMat_tr(6,k) + &
+                     MOMZ_(i,j,7) * filterMat_tr(7,k) + &
+                     MOMZ_(i,j,8) * filterMat_tr(8,k) + &
+                     MOMZ_(i,j,9) * filterMat_tr(9,k) + &
+                     MOMZ_(i,j,10) * filterMat_tr(10,k) + &
+                     MOMZ_(i,j,11) * filterMat_tr(11,k) + &
+                     MOMZ_(i,j,12) * filterMat_tr(12,k) 
+
+      tmp(i,j,k,5) = DRHOT_(i,j,1) * filterMat_tr(1,k) + &
+                     DRHOT_(i,j,2) * filterMat_tr(2,k) + &
+                     DRHOT_(i,j,3) * filterMat_tr(3,k) + &
+                     DRHOT_(i,j,4) * filterMat_tr(4,k) + &
+                     DRHOT_(i,j,5) * filterMat_tr(5,k) + &
+                     DRHOT_(i,j,6) * filterMat_tr(6,k) + &
+                     DRHOT_(i,j,7) * filterMat_tr(7,k) + &
+                     DRHOT_(i,j,8) * filterMat_tr(8,k) + &
+                     DRHOT_(i,j,9) * filterMat_tr(9,k) + &
+                     DRHOT_(i,j,10) * filterMat_tr(10,k) + &
+                     DRHOT_(i,j,11) * filterMat_tr(11,k) + &
+                     DRHOT_(i,j,12) * filterMat_tr(12,k) 
+
+    end do
+    end do
+    end do
+  end subroutine apply_filter_xyz_direction
+
+end module scale_atm_dyn_dgm_modalfilter

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune_p7.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune_p7.F90
@@ -1,0 +1,367 @@
+!-------------------------------------------------------------------------------
+!> module FElib / Fluid dyn solver / Atmosphere / Common / Modal filter
+!!
+!! @par Description
+!!      Modal filter for Atmospheric dynamical process. 
+!!      The modal filter surpresses the numerical instability due to the aliasing errors. 
+!!
+!! @author Team SCALE
+!<
+!-------------------------------------------------------------------------------
+#include "scaleFElib.h"
+module scale_atm_dyn_dgm_modalfilter
+  !-----------------------------------------------------------------------------
+  !
+  !++ Used modules
+  !
+  use scale_precision
+  use scale_io
+
+  use scale_element_base, only: ElementBase
+  use scale_localmesh_base, only: LocalMeshBase
+  use scale_element_modalfilter, only: ModalFilter
+
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public procedures
+  !
+  public :: atm_dyn_dgm_modalfilter_apply
+  public :: atm_dyn_dgm_tracer_modalfilter_apply
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public parameters & variables
+  !
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedures & variables
+  !
+  !-------------------
+  private :: apply_filter_xyz_direction
+contains
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_modalfilter_apply(  &
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_,     & ! (inout)
+    lmesh, elem, filter, do_weight_Gsqrt     ) ! (in)
+
+    implicit none
+
+    class(LocalMeshBase), intent(in) :: lmesh
+    class(ElementBase), intent(in) :: elem    
+    real(RP), intent(inout)  :: DDENS_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMX_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMY_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: MOMZ_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: DRHOT_(elem%Np,lmesh%NeA)
+    class(ModalFilter), intent(in) :: filter
+    logical, intent(in), optional :: do_weight_Gsqrt
+    
+    integer :: ke
+    real(RP) :: tmp(elem%Np,5)
+    real(RP) :: FilterMat_tr(8,8)
+    integer :: ii, kk
+    real(RP) :: Mik
+    logical :: do_weight_Gsqrt_
+    real(RP) :: RGsqrt(elem%Np)
+    !------------------------------------
+    FilterMat_tr(:,:) = transpose(filter%FilterMat(:,:))
+
+
+    if ( present( do_weight_Gsqrt ) ) then
+      do_weight_Gsqrt_ = do_weight_Gsqrt
+    else
+      do_weight_Gsqrt_ = .false.
+    end if
+
+    if ( do_weight_Gsqrt_ ) then
+      !$omp parallel do private( tmp, ii, kk, Mik, RGsqrt )
+      do ke=lmesh%NeS, lmesh%NeE
+
+        tmp(:,:) = 0.0_RP
+        !do ii=1, elem%Np
+        !do kk=1, elem%Np
+        !  Mik = filter%FilterMat(ii,kk) * lmesh%Gsqrt(kk,ke)
+
+        !  tmp(ii,1) = tmp(ii,1) + Mik * DDENS_(kk,ke)
+        !  tmp(ii,2) = tmp(ii,2) + Mik * MOMX_ (kk,ke)
+        !  tmp(ii,3) = tmp(ii,3) + Mik * MOMY_ (kk,ke)
+        !  tmp(ii,4) = tmp(ii,4) + Mik * MOMZ_ (kk,ke)
+        !  tmp(ii,5) = tmp(ii,5) + Mik * DRHOT_(kk,ke)
+        !end do
+        !end do
+
+        do ii=1, elem%Np
+          DDENS_(ii,ke) = lmesh%Gsqrt(ii,ke) * DDENS_(ii,ke)
+          MOMX_(ii,ke) = lmesh%Gsqrt(ii,ke) * MOMX_(ii,ke)
+          MOMY_(ii,ke) = lmesh%Gsqrt(ii,ke) * MOMY_(ii,ke)
+          MOMZ_(ii,ke) = lmesh%Gsqrt(ii,ke) * MOMZ_(ii,ke)
+          DRHOT_(ii,ke) = lmesh%Gsqrt(ii,ke) * DRHOT_(ii,ke)
+        end do
+
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, DDENS_(:,ke), MOMX_(:,ke), MOMY_(:,ke), MOMZ_(:,ke), DRHOT_(:,ke), tmp)
+
+        RGsqrt(:) = 1.0_RP / lmesh%Gsqrt(:,ke)
+        DDENS_(:,ke) = tmp(:,1) * RGsqrt(:)
+        MOMX_ (:,ke) = tmp(:,2) * RGsqrt(:)
+        MOMY_ (:,ke) = tmp(:,3) * RGsqrt(:)
+        MOMZ_ (:,ke) = tmp(:,4) * RGsqrt(:)
+        DRHOT_(:,ke) = tmp(:,5) * RGsqrt(:)
+      end do    
+
+    else
+
+      !$omp parallel do private( tmp, ii, kk, Mik )
+      do ke=lmesh%NeS, lmesh%NeE
+
+        tmp(:,:) = 0.0_RP
+        !do ii=1, elem%Np
+        !do kk=1, elem%Np
+        !  Mik = filter%FilterMat(ii,kk)
+        !  tmp(ii,1) = tmp(ii,1) + Mik * DDENS_(kk,ke)
+        !  tmp(ii,2) = tmp(ii,2) + Mik * MOMX_ (kk,ke)
+        !  tmp(ii,3) = tmp(ii,3) + Mik * MOMY_ (kk,ke)
+        !  tmp(ii,4) = tmp(ii,4) + Mik * MOMZ_ (kk,ke)
+        !  tmp(ii,5) = tmp(ii,5) + Mik * DRHOT_(kk,ke)
+        !end do
+        !end do      
+
+        call apply_filter_xyz_direction(filter%FilterMat, FilterMat_tr, DDENS_(:,ke), MOMX_(:,ke), MOMY_(:,ke), MOMZ_(:,ke), DRHOT_(:,ke), tmp)
+
+        DDENS_(:,ke) = tmp(:,1)
+        MOMX_ (:,ke) = tmp(:,2)
+        MOMY_ (:,ke) = tmp(:,3)
+        MOMZ_ (:,ke) = tmp(:,4)
+        DRHOT_(:,ke) = tmp(:,5)
+      end do
+
+    end if
+
+    return
+  end subroutine atm_dyn_dgm_modalfilter_apply
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_tracer_modalfilter_apply(  &
+    QTRC_,                                   & ! (inout)
+    DENS_hyd_, DDENS_,                       & ! (inout)
+    lmesh, elem, filter                      ) ! (in)
+
+    implicit none
+
+    class(LocalMeshBase), intent(in) :: lmesh
+    class(ElementBase), intent(in) :: elem    
+    real(RP), intent(inout)  :: QTRC_(elem%Np,lmesh%NeA)
+    real(RP), intent(inout)  :: DENS_hyd_(elem%Np,lmesh%NeA)
+    real(RP), intent(in)  :: DDENS_(elem%Np,lmesh%NeA)
+    class(ModalFilter), intent(in) :: filter
+
+    integer :: ke
+    real(RP) :: tmp(elem%Np)
+    integer :: ii, kk
+    real(RP) :: Mik
+
+    real(RP) :: weight(elem%Np)
+    !------------------------------------
+
+    !$omp parallel do private( tmp, ii, kk, Mik, weight )
+    do ke=lmesh%NeS, lmesh%NeE
+
+      tmp(:) = 0.0_RP
+      weight(:) = lmesh%Gsqrt(:,ke) &
+                * ( DENS_hyd_(:,ke) + DDENS_(:,ke) )
+
+      do ii=1, elem%Np
+      do kk=1, elem%Np
+        Mik = filter%FilterMat(ii,kk) * weight(kk)
+
+        tmp(ii) = tmp(ii) + Mik * QTRC_(kk,ke)
+      end do
+      end do
+
+      QTRC_(:,ke) = tmp(:) / weight(:)
+    end do    
+
+    return
+  end subroutine atm_dyn_dgm_tracer_modalfilter_apply
+
+!OCL SERIAL
+  subroutine apply_filter_xyz_direction(filterMat, filterMat_tr, DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, tmp )
+    implicit none
+
+    real(RP), intent(in) :: filterMat(8, 8)
+    real(RP), intent(in) :: filterMat_tr(8, 8)
+    real(RP), intent(inout) :: DDENS_(8, 8, 8)
+    real(RP), intent(inout) :: MOMX_(8, 8, 8)
+    real(RP), intent(inout) :: MOMY_(8, 8, 8)
+    real(RP), intent(inout) :: MOMZ_(8, 8, 8)
+    real(RP), intent(inout) :: DRHOT_(8, 8, 8)
+    real(RP), intent(inout) :: tmp(8, 8, 8, 5)
+    
+    integer :: i, j, k
+
+    !-- x direction
+    do k=1, 8
+    do j=1, 8
+    do i=1, 8
+
+      tmp(i,j,k,1) = filterMat(i,1) * DDENS_(1,j,k) + &
+                     filterMat(i,2) * DDENS_(2,j,k) + &
+                     filterMat(i,3) * DDENS_(3,j,k) + & 
+                     filterMat(i,4) * DDENS_(4,j,k) + & 
+                     filterMat(i,5) * DDENS_(5,j,k) + & 
+                     filterMat(i,6) * DDENS_(6,j,k) + & 
+                     filterMat(i,7) * DDENS_(7,j,k) + & 
+                     filterMat(i,8) * DDENS_(8,j,k)  
+
+      tmp(i,j,k,2) = filterMat(i,1) * MOMX_(1,j,k) + &
+                     filterMat(i,2) * MOMX_(2,j,k) + &
+                     filterMat(i,3) * MOMX_(3,j,k) + & 
+                     filterMat(i,4) * MOMX_(4,j,k) + & 
+                     filterMat(i,5) * MOMX_(5,j,k) + & 
+                     filterMat(i,6) * MOMX_(6,j,k) + & 
+                     filterMat(i,7) * MOMX_(7,j,k) + & 
+                     filterMat(i,8) * MOMX_(8,j,k)  
+
+      tmp(i,j,k,3) = filterMat(i,1) * MOMY_(1,j,k) + &
+                     filterMat(i,2) * MOMY_(2,j,k) + &
+                     filterMat(i,3) * MOMY_(3,j,k) + & 
+                     filterMat(i,4) * MOMY_(4,j,k) + & 
+                     filterMat(i,5) * MOMY_(5,j,k) + & 
+                     filterMat(i,6) * MOMY_(6,j,k) + & 
+                     filterMat(i,7) * MOMY_(7,j,k) + & 
+                     filterMat(i,8) * MOMY_(8,j,k)  
+
+      tmp(i,j,k,4) = filterMat(i,1) * MOMZ_(1,j,k) + &
+                     filterMat(i,2) * MOMZ_(2,j,k) + &
+                     filterMat(i,3) * MOMZ_(3,j,k) + & 
+                     filterMat(i,4) * MOMZ_(4,j,k) + & 
+                     filterMat(i,5) * MOMZ_(5,j,k) + & 
+                     filterMat(i,6) * MOMZ_(6,j,k) + & 
+                     filterMat(i,7) * MOMZ_(7,j,k) + & 
+                     filterMat(i,8) * MOMZ_(8,j,k)  
+
+      tmp(i,j,k,5) = filterMat(i,1) * DRHOT_(1,j,k) + &
+                     filterMat(i,2) * DRHOT_(2,j,k) + &
+                     filterMat(i,3) * DRHOT_(3,j,k) + & 
+                     filterMat(i,4) * DRHOT_(4,j,k) + & 
+                     filterMat(i,5) * DRHOT_(5,j,k) + & 
+                     filterMat(i,6) * DRHOT_(6,j,k) + & 
+                     filterMat(i,7) * DRHOT_(7,j,k) + & 
+                     filterMat(i,8) * DRHOT_(8,j,k)  
+
+    end do
+    end do
+    end do
+
+    !-- y direction
+    do k=1, 8
+    do j=1, 8
+    do i=1, 8
+      DDENS_(i,j,k) = tmp(i,1,k,1) * filterMat_tr(1,j) + &
+                      tmp(i,2,k,1) * filterMat_tr(2,j) + &
+                      tmp(i,3,k,1) * filterMat_tr(3,j) + &
+                      tmp(i,4,k,1) * filterMat_tr(4,j) + &
+                      tmp(i,5,k,1) * filterMat_tr(5,j) + &
+                      tmp(i,6,k,1) * filterMat_tr(6,j) + &
+                      tmp(i,7,k,1) * filterMat_tr(7,j) + &
+                      tmp(i,8,k,1) * filterMat_tr(8,j) 
+
+      MOMX_(i,j,k) = tmp(i,1,k,2) * filterMat_tr(1,j) + &
+                     tmp(i,2,k,2) * filterMat_tr(2,j) + &
+                     tmp(i,3,k,2) * filterMat_tr(3,j) + &
+                     tmp(i,4,k,2) * filterMat_tr(4,j) + &
+                     tmp(i,5,k,2) * filterMat_tr(5,j) + &
+                     tmp(i,6,k,2) * filterMat_tr(6,j) + &
+                     tmp(i,7,k,2) * filterMat_tr(7,j) + &
+                     tmp(i,8,k,2) * filterMat_tr(8,j) 
+
+      MOMY_(i,j,k) = tmp(i,1,k,3) * filterMat_tr(1,j) + &
+                     tmp(i,2,k,3) * filterMat_tr(2,j) + &
+                     tmp(i,3,k,3) * filterMat_tr(3,j) + &
+                     tmp(i,4,k,3) * filterMat_tr(4,j) + &
+                     tmp(i,5,k,3) * filterMat_tr(5,j) + &
+                     tmp(i,6,k,3) * filterMat_tr(6,j) + &
+                     tmp(i,7,k,3) * filterMat_tr(7,j) + &
+                     tmp(i,8,k,3) * filterMat_tr(8,j) 
+
+      MOMZ_(i,j,k) = tmp(i,1,k,4) * filterMat_tr(1,j) + &
+                     tmp(i,2,k,4) * filterMat_tr(2,j) + &
+                     tmp(i,3,k,4) * filterMat_tr(3,j) + &
+                     tmp(i,4,k,4) * filterMat_tr(4,j) + &
+                     tmp(i,5,k,4) * filterMat_tr(5,j) + &
+                     tmp(i,6,k,4) * filterMat_tr(6,j) + &
+                     tmp(i,7,k,4) * filterMat_tr(7,j) + &
+                     tmp(i,8,k,4) * filterMat_tr(8,j) 
+
+      DRHOT_(i,j,k) = tmp(i,1,k,5) * filterMat_tr(1,j) + &
+                      tmp(i,2,k,5) * filterMat_tr(2,j) + &
+                      tmp(i,3,k,5) * filterMat_tr(3,j) + &
+                      tmp(i,4,k,5) * filterMat_tr(4,j) + &
+                      tmp(i,5,k,5) * filterMat_tr(5,j) + &
+                      tmp(i,6,k,5) * filterMat_tr(6,j) + &
+                      tmp(i,7,k,5) * filterMat_tr(7,j) + &
+                      tmp(i,8,k,5) * filterMat_tr(8,j) 
+
+    end do
+    end do
+    end do
+
+    !-- z direction
+    do k=1, 8
+    do j=1, 8
+    do i=1, 8
+      tmp(i,j,k,1) = DDENS_(i,j,1) * filterMat_tr(1,k) + &
+                     DDENS_(i,j,2) * filterMat_tr(2,k) + &
+                     DDENS_(i,j,3) * filterMat_tr(3,k) + &
+                     DDENS_(i,j,4) * filterMat_tr(4,k) + &
+                     DDENS_(i,j,5) * filterMat_tr(5,k) + &
+                     DDENS_(i,j,6) * filterMat_tr(6,k) + &
+                     DDENS_(i,j,7) * filterMat_tr(7,k) + &
+                     DDENS_(i,j,8) * filterMat_tr(8,k) 
+
+      tmp(i,j,k,2) = MOMX_(i,j,1) * filterMat_tr(1,k) + &
+                     MOMX_(i,j,2) * filterMat_tr(2,k) + &
+                     MOMX_(i,j,3) * filterMat_tr(3,k) + &
+                     MOMX_(i,j,4) * filterMat_tr(4,k) + &
+                     MOMX_(i,j,5) * filterMat_tr(5,k) + &
+                     MOMX_(i,j,6) * filterMat_tr(6,k) + &
+                     MOMX_(i,j,7) * filterMat_tr(7,k) + &
+                     MOMX_(i,j,8) * filterMat_tr(8,k) 
+
+      tmp(i,j,k,3) = MOMY_(i,j,1) * filterMat_tr(1,k) + &
+                     MOMY_(i,j,2) * filterMat_tr(2,k) + &
+                     MOMY_(i,j,3) * filterMat_tr(3,k) + &
+                     MOMY_(i,j,4) * filterMat_tr(4,k) + &
+                     MOMY_(i,j,5) * filterMat_tr(5,k) + &
+                     MOMY_(i,j,6) * filterMat_tr(6,k) + &
+                     MOMY_(i,j,7) * filterMat_tr(7,k) + &
+                     MOMY_(i,j,8) * filterMat_tr(8,k) 
+
+      tmp(i,j,k,4) = MOMZ_(i,j,1) * filterMat_tr(1,k) + &
+                     MOMZ_(i,j,2) * filterMat_tr(2,k) + &
+                     MOMZ_(i,j,3) * filterMat_tr(3,k) + &
+                     MOMZ_(i,j,4) * filterMat_tr(4,k) + &
+                     MOMZ_(i,j,5) * filterMat_tr(5,k) + &
+                     MOMZ_(i,j,6) * filterMat_tr(6,k) + &
+                     MOMZ_(i,j,7) * filterMat_tr(7,k) + &
+                     MOMZ_(i,j,8) * filterMat_tr(8,k) 
+
+      tmp(i,j,k,5) = DRHOT_(i,j,1) * filterMat_tr(1,k) + &
+                     DRHOT_(i,j,2) * filterMat_tr(2,k) + &
+                     DRHOT_(i,j,3) * filterMat_tr(3,k) + &
+                     DRHOT_(i,j,4) * filterMat_tr(4,k) + &
+                     DRHOT_(i,j,5) * filterMat_tr(5,k) + &
+                     DRHOT_(i,j,6) * filterMat_tr(6,k) + &
+                     DRHOT_(i,j,7) * filterMat_tr(7,k) + &
+                     DRHOT_(i,j,8) * filterMat_tr(8,k) 
+
+    end do
+    end do
+    end do
+  end subroutine apply_filter_xyz_direction
+
+end module scale_atm_dyn_dgm_modalfilter

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux.F90
@@ -309,6 +309,20 @@ contains
     RovP0 = Rdry * rP0
     P0ovR = PRES00 / Rdry
 
+    !if(PRC_GLOBAL_myrank == 0) then
+    !  write(*,*) "lmesh.NeA", lmesh%NeA
+    !  write(*,*) "lmesh.NeS", lmesh%NeS
+    !  write(*,*) "lmesh.NeE", lmesh%NeE
+
+    !  !-- output vmaps
+    !  open(66, file="vmapP.dat", access="stream", form="unformatted", status="new")
+    !  open(67, file="vmapM.dat", access="stream", form="unformatted", status="new")
+    !  write(66) vmapP(:,:)
+    !  write(67) vmapM(:,:)
+    !  close(66)
+    !  close(67)
+    !end if
+
     !$omp parallel do private( &
     !$omp ke, iM, iP, ke2d,                                                             &
     !$omp alpha, VelM, VelP,                                                            &

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_orig.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_orig.F90
@@ -1,0 +1,428 @@
+!-------------------------------------------------------------------------------
+!> module FElib / Fluid dyn solver / Atmosphere / Nonhydrostatic model / HEVE / Numflux
+!!
+!! @par Description
+!!      HEVE DGM scheme for Atmospheric dynamical process. 
+!!
+!! @author Team SCALE
+!<
+!-------------------------------------------------------------------------------
+#include "scaleFElib.h"
+module scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux
+  !-----------------------------------------------------------------------------
+  !
+  !++ Used modules
+  !
+  use scale_precision
+  use scale_io
+  use scale_prc
+  use scale_prof
+  use scale_const, only: &
+    GRAV => CONST_GRAV,  &
+    Rdry => CONST_Rdry,  &
+    CPdry => CONST_CPdry, &
+    CVdry => CONST_CVdry, &
+    PRES00 => CONST_PRE00
+
+  use scale_sparsemat  
+  use scale_element_base, only: &
+    ElementBase2D, ElementBase3D
+  use scale_element_hexahedral, only: HexahedralElement
+  use scale_localmesh_2d, only: LocalMesh2D  
+  use scale_localmesh_3d, only: LocalMesh3D
+  use scale_mesh_base3d, only: MeshBase3D
+  use scale_localmeshfield_base, only: LocalMeshField3D
+  use scale_meshfield_base, only: MeshField3D
+
+  use scale_atm_dyn_dgm_nonhydro3d_common, only: &
+    DENS_VID => PRGVAR_DDENS_ID, RHOT_VID => PRGVAR_DRHOT_ID, &
+    MOMX_VID => PRGVAR_MOMX_ID, MOMY_VID => PRGVAR_MOMY_ID,   &
+    MOMZ_VID => PRGVAR_MOMZ_ID,                               &
+    PRGVAR_NUM
+  
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public procedures
+  !
+  public :: atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalvc
+  public :: atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalhvc
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public parameters & variables
+  !
+  
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedures & variables
+  !
+  !-------------------
+
+contains
+ 
+!OCL SERIAL
+  subroutine atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalvc( &
+    del_flux, del_flux_hyd,                                          & ! (out)
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd, & ! (in)
+    Rtot, CVtot, CPtot,                                              & ! (in)
+    Gsqrt, G13, G23, nx, ny, nz,                                     & ! (in)
+    vmapM, vmapP, lmesh, elem, lmesh2D, elem2D                       ) ! (in)
+
+    implicit none
+
+    class(LocalMesh3D), intent(in) :: lmesh
+    class(ElementBase3D), intent(in) :: elem  
+    class(LocalMesh2D), intent(in) :: lmesh2D
+    class(ElementBase2D), intent(in) :: elem2D
+    real(RP), intent(out) ::  del_flux(elem%NfpTot,lmesh%Ne,PRGVAR_NUM)
+    real(RP), intent(out) ::  del_flux_hyd(elem%NfpTot,lmesh%Ne,2)
+    real(RP), intent(in) ::  DDENS_(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  MOMX_(elem%Np*lmesh%NeA)  
+    real(RP), intent(in) ::  MOMY_(elem%Np*lmesh%NeA)  
+    real(RP), intent(in) ::  MOMZ_(elem%Np*lmesh%NeA)  
+    real(RP), intent(in) ::  DRHOT_(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  DPRES_(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  DENS_hyd(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  PRES_hyd(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  Rtot (elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  CVtot(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  CPtot(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  Gsqrt(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  G13(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  G23(elem%Np*lmesh%NeA)
+    real(RP), intent(in) :: nx(elem%NfpTot,lmesh%Ne)
+    real(RP), intent(in) :: ny(elem%NfpTot,lmesh%Ne)
+    real(RP), intent(in) :: nz(elem%NfpTot,lmesh%Ne)
+    integer, intent(in) :: vmapM(elem%NfpTot,lmesh%Ne)
+    integer, intent(in) :: vmapP(elem%NfpTot,lmesh%Ne)
+    
+    integer :: ke, i, iP(elem%NfpTot), iM(elem%NfpTot)
+    integer :: ke2D
+    real(RP) :: VelP(elem%NfpTot), VelM(elem%NfpTot), alpha(elem%NfpTot)
+    real(RP) :: dpresP(elem%NfpTot), dpresM(elem%NfpTot)
+    real(RP) :: GsqrtDensM(elem%NfpTot), GsqrtDensP(elem%NfpTot)
+    real(RP) :: GsqrtRhotM(elem%NfpTot), GsqrtRhotP(elem%NfpTot)
+    real(RP) :: GsqrtDDENS_P(elem%NfpTot), GsqrtDDENS_M(elem%NfpTot)
+    real(RP) :: GsqrtMOMX_P(elem%NfpTot), GsqrtMOMX_M(elem%NfpTot)
+    real(RP) :: GsqrtMOMY_P(elem%NfpTot), GsqrtMOMY_M(elem%NfpTot)
+    real(RP) :: GsqrtMOMZ_P(elem%NfpTot), GsqrtMOMZ_M(elem%NfpTot)
+    real(RP) :: GsqrtDRHOT_P(elem%NfpTot), GsqrtDRHOT_M(elem%NfpTot)
+    real(RP) :: Phyd_P(elem%NfpTot), Phyd_M(elem%NfpTot)
+    real(RP) :: Gsqrt_P(elem%NfpTot), Gsqrt_M(elem%NfpTot)
+    real(RP) :: GsqrtV_P(elem%NfpTot), GsqrtV_M(elem%NfpTot)
+    real(RP) :: G13_M(elem%NfpTot), G13_P(elem%NfpTot)
+    real(RP) :: G23_M(elem%NfpTot), G23_P(elem%NfpTot)
+    real(RP) :: Gnn_M(elem%NfpTot), Gnn_P(elem%NfpTot)
+
+    real(RP) :: gamm, rgamm    
+    real(RP) :: rP0
+    real(RP) :: RovP0, P0ovR     
+    !------------------------------------------------------------------------
+
+    gamm  = CPDry / CvDry
+    rgamm = CvDry / CpDry
+    rP0   = 1.0_RP / PRES00
+    RovP0 = Rdry * rP0
+    P0ovR = PRES00 / Rdry
+
+    !$omp parallel do private( &
+    !$omp ke, iM, iP, ke2D,                                                             &
+    !$omp alpha, VelM, VelP,                                                            &
+    !$omp dpresM, dpresP, GsqrtDensM, GsqrtDensP, GsqrtRhotM, GsqrtRhotP,               &
+    !$omp GsqrtMOMX_M, GsqrtMOMX_P, GsqrtMOMY_M, GsqrtMOMY_P, GsqrtMOMZ_M, GsqrtMOMZ_P, &
+    !$omp GsqrtDDENS_M, GsqrtDDENS_P, GsqrtDRHOT_M, GsqrtDRHOT_P,                       &
+    !$omp Phyd_M, Phyd_P,                                                               &
+    !$omp Gsqrt_P, Gsqrt_M, GsqrtV_P, GsqrtV_M, G13_P, G13_M, G23_P, G23_M,             &
+    !$omp Gnn_P, Gnn_M                                                                  )
+    do ke=lmesh%NeS, lmesh%NeE
+      iM(:) = vmapM(:,ke); iP(:) = vmapP(:,ke)
+      ke2D = lmesh%EMap3Dto2D(ke)
+
+      Gsqrt_M(:) = Gsqrt(iM)
+      Gsqrt_P(:) = Gsqrt(iP)
+      GsqrtV_M(:) = Gsqrt_M(:)
+      GsqrtV_P(:) = Gsqrt_P(:)
+
+      G13_M(:) = G13(iM)
+      G13_P(:) = G13(iP)
+      G23_M(:) = G23(iM)
+      G23_P(:) = G23(iP)
+
+      GsqrtDDENS_M(:) = Gsqrt_M(:) * DDENS_(iM)
+      GsqrtDDENS_P(:) = Gsqrt_P(:) * DDENS_(iP)
+      GsqrtMOMX_M (:) = Gsqrt_M(:) * MOMX_ (iM)
+      GsqrtMOMX_P (:) = Gsqrt_P(:) * MOMX_ (iP)
+      GsqrtMOMY_M (:) = Gsqrt_M(:) * MOMY_ (iM)
+      GsqrtMOMY_P (:) = Gsqrt_P(:) * MOMY_ (iP)
+      GsqrtMOMZ_M (:) = Gsqrt_M(:) * MOMZ_ (iM)
+      GsqrtMOMZ_P (:) = Gsqrt_P(:) * MOMZ_ (iP)
+      GsqrtDRHOT_M(:) = Gsqrt_M(:) * DRHOT_(iM)
+      GsqrtDRHOT_P(:) = Gsqrt_P(:) * DRHOT_(iP)
+      Phyd_M(:) = PRES_hyd(iM)
+      Phyd_P(:) = PRES_hyd(iP)
+
+      Gnn_M(:) = abs( nx(:,ke) ) + abs( ny(:,ke) ) &
+               + ( 1.0_RP / GsqrtV_M(:)**2 + G13_M(:)**2 + G23_M(:)**2 ) * abs( nz(:,ke) )
+      Gnn_P(:) = abs( nx(:,ke) ) + abs( ny(:,ke) ) &
+               + ( 1.0_RP / GsqrtV_P(:)**2 + G13_P(:)**2 + G23_P(:)**2 ) * abs( nz(:,ke) )
+
+      GsqrtDensM(:) = GsqrtDDENS_M(:) + Gsqrt_M(:) * DENS_hyd(iM)
+      GsqrtDensP(:) = GsqrtDDENS_P(:) + Gsqrt_P(:) * DENS_hyd(iP)
+
+      GsqrtRhotM(:) = Gsqrt_M(:) * P0ovR * (Phyd_M(:) * rP0)**rgamm + GsqrtDRHOT_M(:)
+      GsqrtRhotP(:) = Gsqrt_P(:) * P0ovR * (Phyd_P(:) * rP0)**rgamm + GsqrtDRHOT_P(:)
+
+      VelM(:) = ( GsqrtMOMX_M(:) * nx(:,ke) + GsqrtMOMY_M(:) * ny(:,ke)                    &
+                + ( ( GsqrtMOMZ_M(:) / GsqrtV_M(:)                                         &
+                    + G13_M(:) * GsqrtMOMX_M(:) + G23_M(:) * GsqrtMOMY_M(:) ) * nz(:,ke) ) &
+                ) / GsqrtDensM(:)
+      VelP(:) = ( GsqrtMOMX_P(:) * nx(:,ke) + GsqrtMOMY_P(:) * ny(:,ke)                    &
+                + ( ( GsqrtMOMZ_P(:) / GsqrtV_P(:)                                         &
+                    + G13_P(:) * GsqrtMOMX_P(:) + G23_P(:) * GsqrtMOMY_P(:) ) * nz(:,ke) ) &
+                ) / GsqrtDensP(:)
+        
+
+      ! dpresM(:) = PRES00 * ( Rtot(iM) * rP0 * GsqrtRhotM(:) / Gsqrt_M(:) )**( CPtot(iM) / CVtot(iM) ) &
+      !           - Phyd_M(:)
+      ! dpresP(:) = PRES00 * ( Rtot(iP) * rP0 * GsqrtRhotP(:) / Gsqrt_P(:) )**( CPtot(iP) / CVtot(iP) ) &
+      !           - Phyd_P(:)
+      dpresM(:) = DPRES_(iM)
+      dpresP(:) = DPRES_(iP)
+
+      alpha(:) = max( sqrt( Gnn_M(:) * gamm * ( Phyd_M(:) + dpresM(:) ) * Gsqrt_M(:) / GsqrtDensM(:) ) + abs(VelM(:)), &
+                      sqrt( Gnn_P(:) * gamm * ( Phyd_P(:) + dpresP(:) ) * Gsqrt_P(:) / GsqrtDensP(:) ) + abs(VelP(:))  )
+      
+      del_flux(:,ke,DENS_VID) = 0.5_RP * ( &
+                    ( GsqrtDensP(:) * VelP(:) - GsqrtDensM(:) * VelM(:) )  &
+                    - alpha(:) * ( GsqrtDDENS_P(:) - GsqrtDDENS_M(:) )     )
+
+      del_flux(:,ke,MOMX_VID ) = 0.5_RP * ( &
+                    ( GsqrtMOMX_P(:) * VelP(:) - GsqrtMOMX_M(:) * VelM(:) )           &
+                    + (  Gsqrt_P(:) * ( nx(:,ke) + G13_P(:) * nz(:,ke)) * dpresP(:)   &
+                       - Gsqrt_M(:) * ( nx(:,ke) + G13_M(:) * nz(:,ke)) * dpresM(:) ) &
+                    - alpha(:) * ( GsqrtMOMX_P(:) - GsqrtMOMX_M(:) )                  )
+
+      del_flux(:,ke,MOMY_VID ) = 0.5_RP * ( &
+                    ( GsqrtMOMY_P(:) * VelP(:) - GsqrtMOMY_M(:) * VelM(:) ) &
+                    + (  Gsqrt_P(:) * ( ny(:,ke) + G23_P(:) * nz(:,ke)) * dpresP(:)   &
+                       - Gsqrt_M(:) * ( ny(:,ke) + G23_M(:) * nz(:,ke)) * dpresM(:) ) &
+                    - alpha(:) * ( GsqrtMOMY_P(:) - GsqrtMOMY_M(:) )        )
+
+      del_flux(:,ke,MOMZ_VID ) = 0.5_RP * ( &
+                    ( GsqrtMOMZ_P(:) * VelP(:) - GsqrtMOMZ_M(:) * VelM(:) ) &
+                    + (  Gsqrt_P(:) * dpresP(:) / GsqrtV_P(:)               &
+                       - Gsqrt_M(:) * dpresM(:) / GsqrtV_M(:) ) * nz(:,ke)  &
+                    - alpha(:) * ( GsqrtMOMZ_P(:) - GsqrtMOMZ_M(:) )        )
+                    
+      del_flux(:,ke,RHOT_VID) = 0.5_RP * ( &
+                    ( GsqrtRhotP(:) * VelP(:) - GsqrtRhotM(:) * VelM(:) )   &
+                    - alpha(:) * ( GsqrtDRHOT_P(:) - GsqrtDRHOT_M(:) )      )
+
+      del_flux_hyd(:,ke,1) = 0.5_RP * ( &
+          GsqrtV_P(:) * ( nx(:,ke) + G13_P(:) * nz(:,ke) ) * Phyd_P(:) &
+        - GsqrtV_M(:) * ( nx(:,ke) + G13_M(:) * nz(:,ke) ) * Phyd_M(:) )
+      
+      del_flux_hyd(:,ke,2) = 0.5_RP * ( &
+          GsqrtV_P(:) * ( ny(:,ke) + G23_P(:) * nz(:,ke) ) * Phyd_P(:) &
+        - GsqrtV_M(:) * ( ny(:,ke) + G23_M(:) * nz(:,ke) ) * Phyd_M(:) )
+    end do
+
+    return
+  end subroutine atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalvc
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalhvc( &
+    del_flux, del_flux_hyd,                                           & ! (out)
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd,  & ! (in)
+    Rtot, CVtot, CPtot,                                               & ! (in)
+    Gsqrt, G11, G12, G22, GsqrtH, gam, G13, G23, nx, ny, nz,          & ! (in)
+    vmapM, vmapP, iM2Dto3D, lmesh, elem, lmesh2D, elem2D              ) ! (in)
+
+    implicit none
+
+    class(LocalMesh3D), intent(in) :: lmesh
+    class(ElementBase3D), intent(in) :: elem
+    class(LocalMesh2D), intent(in) :: lmesh2D
+    class(ElementBase2D), intent(in) :: elem2D
+    real(RP), intent(out) ::  del_flux(elem%NfpTot,lmesh%Ne,PRGVAR_NUM)
+    real(RP), intent(out) ::  del_flux_hyd(elem%NfpTot,lmesh%Ne,2)
+    real(RP), intent(in) ::  DDENS_(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  MOMX_(elem%Np*lmesh%NeA)  
+    real(RP), intent(in) ::  MOMY_(elem%Np*lmesh%NeA)  
+    real(RP), intent(in) ::  MOMZ_(elem%Np*lmesh%NeA)  
+    real(RP), intent(in) ::  DRHOT_(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  DPRES_(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  DENS_hyd(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  PRES_hyd(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  Rtot (elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  CVtot(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  CPtot(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  Gsqrt(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  G11(elem2D%Np,lmesh2D%Ne)
+    real(RP), intent(in) ::  G12(elem2D%Np,lmesh2D%Ne)
+    real(RP), intent(in) ::  G22(elem2D%Np,lmesh2D%Ne)
+    real(RP), intent(in) ::  GsqrtH(elem2D%Np,lmesh2D%Ne)
+    real(RP), intent(in) :: gam(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  G13(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  G23(elem%Np*lmesh%NeA)
+    real(RP), intent(in) :: nx(elem%NfpTot,lmesh%Ne)
+    real(RP), intent(in) :: ny(elem%NfpTot,lmesh%Ne)
+    real(RP), intent(in) :: nz(elem%NfpTot,lmesh%Ne)
+    integer, intent(in) :: vmapM(elem%NfpTot,lmesh%Ne)
+    integer, intent(in) :: vmapP(elem%NfpTot,lmesh%Ne)
+    integer, intent(in) :: iM2Dto3D(elem%NfpTot)
+    
+    integer :: ke, iP(elem%NfpTot), iM(elem%NfpTot)
+    integer :: ke2D
+    real(RP) :: VelP(elem%NfpTot), VelM(elem%NfpTot), alpha(elem%NfpTot)
+    real(RP) :: dpresP(elem%NfpTot), dpresM(elem%NfpTot)
+    real(RP) :: GsqrtDensM(elem%NfpTot), GsqrtDensP(elem%NfpTot)
+    real(RP) :: GsqrtRhotM(elem%NfpTot), GsqrtRhotP(elem%NfpTot)
+    real(RP) :: GsqrtDDENS_P(elem%NfpTot), GsqrtDDENS_M(elem%NfpTot)
+    real(RP) :: GsqrtMOMX_P(elem%NfpTot), GsqrtMOMX_M(elem%NfpTot)
+    real(RP) :: GsqrtMOMY_P(elem%NfpTot), GsqrtMOMY_M(elem%NfpTot)
+    real(RP) :: GsqrtMOMZ_P(elem%NfpTot), GsqrtMOMZ_M(elem%NfpTot)
+    real(RP) :: GsqrtDRHOT_P(elem%NfpTot), GsqrtDRHOT_M(elem%NfpTot)
+    real(RP) :: Phyd_P(elem%NfpTot), Phyd_M(elem%NfpTot)
+    real(RP) :: Gsqrt_P(elem%NfpTot), Gsqrt_M(elem%NfpTot)
+    real(RP) :: GsqrtV_P(elem%NfpTot), GsqrtV_M(elem%NfpTot)
+    real(RP) :: G13_M(elem%NfpTot), G13_P(elem%NfpTot)
+    real(RP) :: G23_M(elem%NfpTot), G23_P(elem%NfpTot)
+    real(RP) :: G1n_M(elem%NfpTot), G2n_M(elem%NfpTot)
+    real(RP) :: Gnn_M(elem%NfpTot), Gnn_P(elem%NfpTot)
+    real(RP) :: Gxz_M(elem%NfpTot), Gxz_P(elem%NfpTot)
+    real(RP) :: Gyz_M(elem%NfpTot), Gyz_P(elem%NfpTot)
+    real(RP) :: rgam2_M(elem%NfpTot), rgam2_P(elem%NfpTot)
+
+    real(RP) :: gamm, rgamm    
+    real(RP) :: rP0
+    real(RP) :: RovP0, P0ovR
+
+    !------------------------------------------------------------------------
+
+    gamm  = CPDry / CvDry
+    rgamm = CvDry / CpDry
+    rP0   = 1.0_RP / PRES00
+    RovP0 = Rdry * rP0
+    P0ovR = PRES00 / Rdry
+
+    !$omp parallel do private( &
+    !$omp ke, iM, iP, ke2d,                                                             &
+    !$omp alpha, VelM, VelP,                                                            &
+    !$omp dpresM, dpresP, GsqrtDensM, GsqrtDensP, GsqrtRhotM, GsqrtRhotP,               &
+    !$omp GsqrtMOMX_M, GsqrtMOMX_P, GsqrtMOMY_M, GsqrtMOMY_P, GsqrtMOMZ_M, GsqrtMOMZ_P, &
+    !$omp GsqrtDDENS_M, GsqrtDDENS_P, GsqrtDRHOT_M, GsqrtDRHOT_P,                       &
+    !$omp Phyd_M, Phyd_P,                                                               &
+    !$omp Gsqrt_P, Gsqrt_M, GsqrtV_P, GsqrtV_M, G13_P, G13_M, G23_P, G23_M,             &
+    !$omp rgam2_M, rgam2_P, Gxz_P, Gxz_M, Gyz_P, Gyz_M, G1n_M, G2n_M, Gnn_P, Gnn_M      )
+    do ke=lmesh%NeS, lmesh%NeE
+      iM(:) = vmapM(:,ke); iP(:) = vmapP(:,ke)
+      ke2D = lmesh%EMap3Dto2D(ke)
+
+      Gsqrt_M(:) = Gsqrt(iM)
+      Gsqrt_P(:) = Gsqrt(iP)
+
+      rgam2_M(:) = 1.0_RP / gam(iM)**2
+      rgam2_P(:) = 1.0_RP / gam(iP)**2
+      GsqrtV_M(:) = Gsqrt_M(:) * rgam2_M(:) / GsqrtH(iM2Dto3D(:),ke2D)
+      GsqrtV_P(:) = Gsqrt_P(:) * rgam2_P(:) / GsqrtH(iM2Dto3D(:),ke2D)
+
+      G13_M(:) = G13(iM)
+      G13_P(:) = G13(iP)
+      G23_M(:) = G23(iM)
+      G23_P(:) = G23(iP)
+
+      GsqrtDDENS_M(:) = Gsqrt_M(:) * DDENS_(iM)
+      GsqrtDDENS_P(:) = Gsqrt_P(:) * DDENS_(iP)
+      GsqrtMOMX_M (:) = Gsqrt_M(:) * MOMX_ (iM)
+      GsqrtMOMX_P (:) = Gsqrt_P(:) * MOMX_ (iP)
+      GsqrtMOMY_M (:) = Gsqrt_M(:) * MOMY_ (iM)
+      GsqrtMOMY_P (:) = Gsqrt_P(:) * MOMY_ (iP)
+      GsqrtMOMZ_M (:) = Gsqrt_M(:) * MOMZ_ (iM)
+      GsqrtMOMZ_P (:) = Gsqrt_P(:) * MOMZ_ (iP)
+      GsqrtDRHOT_M(:) = Gsqrt_M(:) * DRHOT_(iM)
+      GsqrtDRHOT_P(:) = Gsqrt_P(:) * DRHOT_(iP)
+      Phyd_M(:) = PRES_hyd(iM)
+      Phyd_P(:) = PRES_hyd(iP)
+
+      Gxz_M(:) = rgam2_M(:) * ( G11(iM2Dto3D(:),ke2D) * G13_M(:) + G12(iM2Dto3D(:),ke2D) * G23_M(:) )
+      Gxz_P(:) = rgam2_P(:) * ( G11(iM2Dto3D(:),ke2D) * G13_P(:) + G12(iM2Dto3D(:),ke2D) * G23_P(:) )
+
+      Gyz_M(:) = rgam2_M(:) * ( G12(iM2Dto3D(:),ke2D) * G13_M(:) + G22(iM2Dto3D(:),ke2D) * G23_M(:) )
+      Gyz_P(:) = rgam2_P(:) * ( G12(iM2Dto3D(:),ke2D) * G13_P(:) + G22(iM2Dto3D(:),ke2D) * G23_P(:) )
+               
+      G1n_M(:) = rgam2_M(:) * ( G11(iM2Dto3D(:),ke2D) * nx(:,ke) + G12(iM2Dto3D(:),ke2D) * ny(:,ke) )
+      G2n_M(:) = rgam2_P(:) * ( G12(iM2Dto3D(:),ke2D) * nx(:,ke) + G22(iM2Dto3D(:),ke2D) * ny(:,ke) )
+
+      Gnn_M(:)  = rgam2_M(:) * ( G11(iM2Dto3D(:),ke2D) * abs( nx(:,ke) ) + G22(iM2Dto3D(:),ke2D) * abs( ny(:,ke) ) ) &
+                + ( 1.0_RP / GsqrtV_M(:)**2 + G13_M(:) * Gxz_M(:) + G23_M(:) * Gyz_M(:) ) * abs( nz(:,ke) )
+      Gnn_P(:)  = rgam2_P(:) * ( G11(iM2Dto3D(:),ke2D) * abs( nx(:,ke) ) + G22(iM2Dto3D(:),ke2D) * abs( ny(:,ke) ) ) &
+                + ( 1.0_RP / GsqrtV_P(:)**2 + G13_P(:) * Gxz_P(:) + G23_P(:) * Gyz_P(:) ) * abs( nz(:,ke) )
+
+      GsqrtDensM(:) = GsqrtDDENS_M(:) + Gsqrt_M(:) * DENS_hyd(iM)
+      GsqrtDensP(:) = GsqrtDDENS_P(:) + Gsqrt_P(:) * DENS_hyd(iP)
+
+      GsqrtRhotM(:) = Gsqrt_M(:) * P0ovR * (Phyd_M(:) * rP0)**rgamm + GsqrtDRHOT_M(:)
+      GsqrtRhotP(:) = Gsqrt_P(:) * P0ovR * (Phyd_P(:) * rP0)**rgamm + GsqrtDRHOT_P(:)
+
+      VelM(:) = ( GsqrtMOMX_M(:) * nx(:,ke) + GsqrtMOMY_M(:) * ny(:,ke)                    &
+                + ( ( GsqrtMOMZ_M(:) / GsqrtV_M(:)                                         &
+                    + G13_M(:) * GsqrtMOMX_M(:) + G23_M(:) * GsqrtMOMY_M(:) ) * nz(:,ke) ) &
+                ) / GsqrtDensM(:)
+      VelP(:) = ( GsqrtMOMX_P(:) * nx(:,ke) + GsqrtMOMY_P(:) * ny(:,ke)                    &
+                + ( ( GsqrtMOMZ_P(:) / GsqrtV_P(:)                                         &
+                    + G13_P(:) * GsqrtMOMX_P(:) + G23_P(:) * GsqrtMOMY_P(:) ) * nz(:,ke) ) &
+                ) / GsqrtDensP(:)
+
+      ! dpresM(:) = PRES00 * ( Rtot(iM) * rP0 * GsqrtRhotM(:) / Gsqrt_M(:) )**( CPtot(iM) / CVtot(iM) ) &
+      !           - Phyd_M(:)
+      ! dpresP(:) = PRES00 * ( Rtot(iP) * rP0 * GsqrtRhotP(:) / Gsqrt_P(:) )**( CPtot(iP) / CVtot(iP) ) &
+      !           - Phyd_P(:)
+      dpresM(:) = DPRES_(iM)
+      dpresP(:) = DPRES_(iP)
+
+      alpha(:) = max( sqrt( Gnn_M(:) * gamm * ( Phyd_M(:) + dpresM(:) ) * Gsqrt_M(:) / GsqrtDensM(:) ) + abs(VelM(:)), &
+                      sqrt( Gnn_P(:) * gamm * ( Phyd_P(:) + dpresP(:) ) * Gsqrt_P(:) / GsqrtDensP(:) ) + abs(VelP(:))  )
+
+      del_flux(:,ke,DENS_VID) = 0.5_RP * ( &
+                    ( GsqrtDensP(:) * VelP(:) - GsqrtDensM(:) * VelM(:) )  &
+                    - alpha(:) * ( GsqrtDDENS_P(:) - GsqrtDDENS_M(:) )     )
+
+      del_flux(:,ke,MOMX_VID ) = 0.5_RP * ( &
+                    ( GsqrtMOMX_P(:) * VelP(:) - GsqrtMOMX_M(:) * VelM(:) )           &
+                    + (  Gsqrt_P(:) * ( G1n_M(:) + Gxz_P(:) * nz(:,ke)) * dpresP(:)   &
+                       - Gsqrt_M(:) * ( G1n_M(:) + Gxz_M(:) * nz(:,ke)) * dpresM(:) ) &
+                    - alpha(:) * ( GsqrtMOMX_P(:) - GsqrtMOMX_M(:) )                  )
+
+      del_flux(:,ke,MOMY_VID ) = 0.5_RP * ( &
+                    ( GsqrtMOMY_P(:) * VelP(:) - GsqrtMOMY_M(:) * VelM(:) )            &
+                    + (  Gsqrt_P(:) * ( G2n_M(:) + Gyz_P(:) * nz(:,ke) ) * dpresP(:)   &
+                       - Gsqrt_M(:) * ( G2n_M(:) + Gyz_M(:) * nz(:,ke) ) * dpresM(:) ) &
+                    - alpha(:) * ( GsqrtMOMY_P(:) - GsqrtMOMY_M(:) )        )
+
+      del_flux(:,ke,MOMZ_VID ) = 0.5_RP * ( &
+                    ( GsqrtMOMZ_P(:) * VelP(:) - GsqrtMOMZ_M(:) * VelM(:) ) &
+                    + (  Gsqrt_P(:) * dpresP(:) / GsqrtV_P(:)               &
+                       - Gsqrt_M(:) * dpresM(:) / GsqrtV_M(:) ) * nz(:,ke)  &
+                    - alpha(:) * ( GsqrtMOMZ_P(:) - GsqrtMOMZ_M(:) )        )
+                    
+      del_flux(:,ke,RHOT_VID) = 0.5_RP * ( &
+                    ( GsqrtRhotP(:) * VelP(:) - GsqrtRhotM(:) * VelM(:) )   &
+                    - alpha(:) * ( GsqrtDRHOT_P(:) - GsqrtDRHOT_M(:) )      )
+
+      del_flux_hyd(:,ke,1) = 0.5_RP * ( &
+          GsqrtV_P(:) * ( nx(:,ke) + G13_P(:) * nz(:,ke) ) * Phyd_P(:) &
+        - GsqrtV_M(:) * ( nx(:,ke) + G13_M(:) * nz(:,ke) ) * Phyd_M(:) )
+      
+      del_flux_hyd(:,ke,2) = 0.5_RP * ( &
+          GsqrtV_P(:) * ( ny(:,ke) + G23_P(:) * nz(:,ke) ) * Phyd_P(:) &
+        - GsqrtV_M(:) * ( ny(:,ke) + G23_M(:) * nz(:,ke) ) * Phyd_M(:) )
+    end do
+
+    return
+  end subroutine atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalhvc
+
+end module scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux

--- a/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_tune1.F90
+++ b/FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_tune1.F90
@@ -1,0 +1,494 @@
+!-------------------------------------------------------------------------------
+!> module FElib / Fluid dyn solver / Atmosphere / Nonhydrostatic model / HEVE / Numflux
+!!
+!! @par Description
+!!      HEVE DGM scheme for Atmospheric dynamical process. 
+!!
+!! @author Team SCALE
+!<
+!-------------------------------------------------------------------------------
+#include "scaleFElib.h"
+module scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux
+  !-----------------------------------------------------------------------------
+  !
+  !++ Used modules
+  !
+  use scale_precision
+  use scale_io
+  use scale_prc
+  use scale_prof
+  use scale_const, only: &
+    GRAV => CONST_GRAV,  &
+    Rdry => CONST_Rdry,  &
+    CPdry => CONST_CPdry, &
+    CVdry => CONST_CVdry, &
+    PRES00 => CONST_PRE00
+
+  use scale_sparsemat  
+  use scale_element_base, only: &
+    ElementBase2D, ElementBase3D
+  use scale_element_hexahedral, only: HexahedralElement
+  use scale_localmesh_2d, only: LocalMesh2D  
+  use scale_localmesh_3d, only: LocalMesh3D
+  use scale_mesh_base3d, only: MeshBase3D
+  use scale_localmeshfield_base, only: LocalMeshField3D
+  use scale_meshfield_base, only: MeshField3D
+
+  use scale_atm_dyn_dgm_nonhydro3d_common, only: &
+    DENS_VID => PRGVAR_DDENS_ID, RHOT_VID => PRGVAR_DRHOT_ID, &
+    MOMX_VID => PRGVAR_MOMX_ID, MOMY_VID => PRGVAR_MOMY_ID,   &
+    MOMZ_VID => PRGVAR_MOMZ_ID,                               &
+    PRGVAR_NUM
+  
+  !-----------------------------------------------------------------------------
+  implicit none
+  private
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public procedures
+  !
+  public :: atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalvc
+  public :: atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalhvc
+
+  !-----------------------------------------------------------------------------
+  !
+  !++ Public parameters & variables
+  !
+  
+  !-----------------------------------------------------------------------------
+  !
+  !++ Private procedures & variables
+  !
+  !-------------------
+
+contains
+ 
+!OCL SERIAL
+  subroutine atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalvc( &
+    del_flux, del_flux_hyd,                                          & ! (out)
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd, & ! (in)
+    Rtot, CVtot, CPtot,                                              & ! (in)
+    Gsqrt, G13, G23, nx, ny, nz,                                     & ! (in)
+    vmapM, vmapP, lmesh, elem, lmesh2D, elem2D                       ) ! (in)
+
+    implicit none
+
+    class(LocalMesh3D), intent(in) :: lmesh
+    class(ElementBase3D), intent(in) :: elem  
+    class(LocalMesh2D), intent(in) :: lmesh2D
+    class(ElementBase2D), intent(in) :: elem2D
+    real(RP), intent(out) ::  del_flux(elem%NfpTot,lmesh%Ne,PRGVAR_NUM)
+    real(RP), intent(out) ::  del_flux_hyd(elem%NfpTot,lmesh%Ne,2)
+    real(RP), intent(in) ::  DDENS_(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  MOMX_(elem%Np*lmesh%NeA)  
+    real(RP), intent(in) ::  MOMY_(elem%Np*lmesh%NeA)  
+    real(RP), intent(in) ::  MOMZ_(elem%Np*lmesh%NeA)  
+    real(RP), intent(in) ::  DRHOT_(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  DPRES_(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  DENS_hyd(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  PRES_hyd(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  Rtot (elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  CVtot(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  CPtot(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  Gsqrt(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  G13(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  G23(elem%Np*lmesh%NeA)
+    real(RP), intent(in) :: nx(elem%NfpTot,lmesh%Ne)
+    real(RP), intent(in) :: ny(elem%NfpTot,lmesh%Ne)
+    real(RP), intent(in) :: nz(elem%NfpTot,lmesh%Ne)
+    integer, intent(in) :: vmapM(elem%NfpTot,lmesh%Ne)
+    integer, intent(in) :: vmapP(elem%NfpTot,lmesh%Ne)
+    
+    integer :: ke, i, iP(elem%NfpTot), iM(elem%NfpTot)
+    integer :: ke2D
+    real(RP) :: VelP(elem%NfpTot), VelM(elem%NfpTot), alpha(elem%NfpTot)
+    real(RP) :: dpresP(elem%NfpTot), dpresM(elem%NfpTot)
+    real(RP) :: GsqrtDensM(elem%NfpTot), GsqrtDensP(elem%NfpTot)
+    real(RP) :: GsqrtRhotM(elem%NfpTot), GsqrtRhotP(elem%NfpTot)
+    real(RP) :: GsqrtDDENS_P(elem%NfpTot), GsqrtDDENS_M(elem%NfpTot)
+    real(RP) :: GsqrtMOMX_P(elem%NfpTot), GsqrtMOMX_M(elem%NfpTot)
+    real(RP) :: GsqrtMOMY_P(elem%NfpTot), GsqrtMOMY_M(elem%NfpTot)
+    real(RP) :: GsqrtMOMZ_P(elem%NfpTot), GsqrtMOMZ_M(elem%NfpTot)
+    real(RP) :: GsqrtDRHOT_P(elem%NfpTot), GsqrtDRHOT_M(elem%NfpTot)
+    real(RP) :: Phyd_P(elem%NfpTot), Phyd_M(elem%NfpTot)
+    real(RP) :: Gsqrt_P(elem%NfpTot), Gsqrt_M(elem%NfpTot)
+    real(RP) :: GsqrtV_P(elem%NfpTot), GsqrtV_M(elem%NfpTot)
+    real(RP) :: G13_M(elem%NfpTot), G13_P(elem%NfpTot)
+    real(RP) :: G23_M(elem%NfpTot), G23_P(elem%NfpTot)
+    real(RP) :: Gnn_M(elem%NfpTot), Gnn_P(elem%NfpTot)
+
+    real(RP) :: gamm, rgamm    
+    real(RP) :: rP0
+    real(RP) :: RovP0, P0ovR     
+    !------------------------------------------------------------------------
+
+    gamm  = CPDry / CvDry
+    rgamm = CvDry / CpDry
+    rP0   = 1.0_RP / PRES00
+    RovP0 = Rdry * rP0
+    P0ovR = PRES00 / Rdry
+
+    !$omp parallel do private( &
+    !$omp ke, iM, iP, ke2D,                                                             &
+    !$omp alpha, VelM, VelP,                                                            &
+    !$omp dpresM, dpresP, GsqrtDensM, GsqrtDensP, GsqrtRhotM, GsqrtRhotP,               &
+    !$omp GsqrtMOMX_M, GsqrtMOMX_P, GsqrtMOMY_M, GsqrtMOMY_P, GsqrtMOMZ_M, GsqrtMOMZ_P, &
+    !$omp GsqrtDDENS_M, GsqrtDDENS_P, GsqrtDRHOT_M, GsqrtDRHOT_P,                       &
+    !$omp Phyd_M, Phyd_P,                                                               &
+    !$omp Gsqrt_P, Gsqrt_M, GsqrtV_P, GsqrtV_M, G13_P, G13_M, G23_P, G23_M,             &
+    !$omp Gnn_P, Gnn_M                                                                  )
+    do ke=lmesh%NeS, lmesh%NeE
+      iM(:) = vmapM(:,ke); iP(:) = vmapP(:,ke)
+      ke2D = lmesh%EMap3Dto2D(ke)
+
+      Gsqrt_M(:) = Gsqrt(iM)
+      Gsqrt_P(:) = Gsqrt(iP)
+      GsqrtV_M(:) = Gsqrt_M(:)
+      GsqrtV_P(:) = Gsqrt_P(:)
+
+      G13_M(:) = G13(iM)
+      G13_P(:) = G13(iP)
+      G23_M(:) = G23(iM)
+      G23_P(:) = G23(iP)
+
+      GsqrtDDENS_M(:) = Gsqrt_M(:) * DDENS_(iM)
+      GsqrtDDENS_P(:) = Gsqrt_P(:) * DDENS_(iP)
+      GsqrtMOMX_M (:) = Gsqrt_M(:) * MOMX_ (iM)
+      GsqrtMOMX_P (:) = Gsqrt_P(:) * MOMX_ (iP)
+      GsqrtMOMY_M (:) = Gsqrt_M(:) * MOMY_ (iM)
+      GsqrtMOMY_P (:) = Gsqrt_P(:) * MOMY_ (iP)
+      GsqrtMOMZ_M (:) = Gsqrt_M(:) * MOMZ_ (iM)
+      GsqrtMOMZ_P (:) = Gsqrt_P(:) * MOMZ_ (iP)
+      GsqrtDRHOT_M(:) = Gsqrt_M(:) * DRHOT_(iM)
+      GsqrtDRHOT_P(:) = Gsqrt_P(:) * DRHOT_(iP)
+      Phyd_M(:) = PRES_hyd(iM)
+      Phyd_P(:) = PRES_hyd(iP)
+
+      Gnn_M(:) = abs( nx(:,ke) ) + abs( ny(:,ke) ) &
+               + ( 1.0_RP / GsqrtV_M(:)**2 + G13_M(:)**2 + G23_M(:)**2 ) * abs( nz(:,ke) )
+      Gnn_P(:) = abs( nx(:,ke) ) + abs( ny(:,ke) ) &
+               + ( 1.0_RP / GsqrtV_P(:)**2 + G13_P(:)**2 + G23_P(:)**2 ) * abs( nz(:,ke) )
+
+      GsqrtDensM(:) = GsqrtDDENS_M(:) + Gsqrt_M(:) * DENS_hyd(iM)
+      GsqrtDensP(:) = GsqrtDDENS_P(:) + Gsqrt_P(:) * DENS_hyd(iP)
+
+      GsqrtRhotM(:) = Gsqrt_M(:) * P0ovR * (Phyd_M(:) * rP0)**rgamm + GsqrtDRHOT_M(:)
+      GsqrtRhotP(:) = Gsqrt_P(:) * P0ovR * (Phyd_P(:) * rP0)**rgamm + GsqrtDRHOT_P(:)
+
+      VelM(:) = ( GsqrtMOMX_M(:) * nx(:,ke) + GsqrtMOMY_M(:) * ny(:,ke)                    &
+                + ( ( GsqrtMOMZ_M(:) / GsqrtV_M(:)                                         &
+                    + G13_M(:) * GsqrtMOMX_M(:) + G23_M(:) * GsqrtMOMY_M(:) ) * nz(:,ke) ) &
+                ) / GsqrtDensM(:)
+      VelP(:) = ( GsqrtMOMX_P(:) * nx(:,ke) + GsqrtMOMY_P(:) * ny(:,ke)                    &
+                + ( ( GsqrtMOMZ_P(:) / GsqrtV_P(:)                                         &
+                    + G13_P(:) * GsqrtMOMX_P(:) + G23_P(:) * GsqrtMOMY_P(:) ) * nz(:,ke) ) &
+                ) / GsqrtDensP(:)
+        
+
+      ! dpresM(:) = PRES00 * ( Rtot(iM) * rP0 * GsqrtRhotM(:) / Gsqrt_M(:) )**( CPtot(iM) / CVtot(iM) ) &
+      !           - Phyd_M(:)
+      ! dpresP(:) = PRES00 * ( Rtot(iP) * rP0 * GsqrtRhotP(:) / Gsqrt_P(:) )**( CPtot(iP) / CVtot(iP) ) &
+      !           - Phyd_P(:)
+      dpresM(:) = DPRES_(iM)
+      dpresP(:) = DPRES_(iP)
+
+      alpha(:) = max( sqrt( Gnn_M(:) * gamm * ( Phyd_M(:) + dpresM(:) ) * Gsqrt_M(:) / GsqrtDensM(:) ) + abs(VelM(:)), &
+                      sqrt( Gnn_P(:) * gamm * ( Phyd_P(:) + dpresP(:) ) * Gsqrt_P(:) / GsqrtDensP(:) ) + abs(VelP(:))  )
+      
+      del_flux(:,ke,DENS_VID) = 0.5_RP * ( &
+                    ( GsqrtDensP(:) * VelP(:) - GsqrtDensM(:) * VelM(:) )  &
+                    - alpha(:) * ( GsqrtDDENS_P(:) - GsqrtDDENS_M(:) )     )
+
+      del_flux(:,ke,MOMX_VID ) = 0.5_RP * ( &
+                    ( GsqrtMOMX_P(:) * VelP(:) - GsqrtMOMX_M(:) * VelM(:) )           &
+                    + (  Gsqrt_P(:) * ( nx(:,ke) + G13_P(:) * nz(:,ke)) * dpresP(:)   &
+                       - Gsqrt_M(:) * ( nx(:,ke) + G13_M(:) * nz(:,ke)) * dpresM(:) ) &
+                    - alpha(:) * ( GsqrtMOMX_P(:) - GsqrtMOMX_M(:) )                  )
+
+      del_flux(:,ke,MOMY_VID ) = 0.5_RP * ( &
+                    ( GsqrtMOMY_P(:) * VelP(:) - GsqrtMOMY_M(:) * VelM(:) ) &
+                    + (  Gsqrt_P(:) * ( ny(:,ke) + G23_P(:) * nz(:,ke)) * dpresP(:)   &
+                       - Gsqrt_M(:) * ( ny(:,ke) + G23_M(:) * nz(:,ke)) * dpresM(:) ) &
+                    - alpha(:) * ( GsqrtMOMY_P(:) - GsqrtMOMY_M(:) )        )
+
+      del_flux(:,ke,MOMZ_VID ) = 0.5_RP * ( &
+                    ( GsqrtMOMZ_P(:) * VelP(:) - GsqrtMOMZ_M(:) * VelM(:) ) &
+                    + (  Gsqrt_P(:) * dpresP(:) / GsqrtV_P(:)               &
+                       - Gsqrt_M(:) * dpresM(:) / GsqrtV_M(:) ) * nz(:,ke)  &
+                    - alpha(:) * ( GsqrtMOMZ_P(:) - GsqrtMOMZ_M(:) )        )
+                    
+      del_flux(:,ke,RHOT_VID) = 0.5_RP * ( &
+                    ( GsqrtRhotP(:) * VelP(:) - GsqrtRhotM(:) * VelM(:) )   &
+                    - alpha(:) * ( GsqrtDRHOT_P(:) - GsqrtDRHOT_M(:) )      )
+
+      del_flux_hyd(:,ke,1) = 0.5_RP * ( &
+          GsqrtV_P(:) * ( nx(:,ke) + G13_P(:) * nz(:,ke) ) * Phyd_P(:) &
+        - GsqrtV_M(:) * ( nx(:,ke) + G13_M(:) * nz(:,ke) ) * Phyd_M(:) )
+      
+      del_flux_hyd(:,ke,2) = 0.5_RP * ( &
+          GsqrtV_P(:) * ( ny(:,ke) + G23_P(:) * nz(:,ke) ) * Phyd_P(:) &
+        - GsqrtV_M(:) * ( ny(:,ke) + G23_M(:) * nz(:,ke) ) * Phyd_M(:) )
+    end do
+
+    return
+  end subroutine atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalvc
+
+!OCL SERIAL
+  subroutine atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalhvc( &
+    del_flux, del_flux_hyd,                                           & ! (out)
+    DDENS_, MOMX_, MOMY_, MOMZ_, DRHOT_, DPRES_, DENS_hyd, PRES_hyd,  & ! (in)
+    Rtot, CVtot, CPtot,                                               & ! (in)
+    Gsqrt, G11, G12, G22, GsqrtH, gam, G13, G23, nx, ny, nz,          & ! (in)
+    vmapM, vmapP, iM2Dto3D, lmesh, elem, lmesh2D, elem2D              ) ! (in)
+
+    implicit none
+
+    class(LocalMesh3D), intent(in) :: lmesh
+    class(ElementBase3D), intent(in) :: elem
+    class(LocalMesh2D), intent(in) :: lmesh2D
+    class(ElementBase2D), intent(in) :: elem2D
+    real(RP), intent(out) ::  del_flux(elem%NfpTot,lmesh%Ne,PRGVAR_NUM)
+    real(RP), intent(out) ::  del_flux_hyd(elem%NfpTot,lmesh%Ne,2)
+    real(RP), intent(in) ::  DDENS_(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  MOMX_(elem%Np*lmesh%NeA)  
+    real(RP), intent(in) ::  MOMY_(elem%Np*lmesh%NeA)  
+    real(RP), intent(in) ::  MOMZ_(elem%Np*lmesh%NeA)  
+    real(RP), intent(in) ::  DRHOT_(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  DPRES_(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  DENS_hyd(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  PRES_hyd(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  Rtot (elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  CVtot(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  CPtot(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  Gsqrt(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  G11(elem2D%Np,lmesh2D%Ne)
+    real(RP), intent(in) ::  G12(elem2D%Np,lmesh2D%Ne)
+    real(RP), intent(in) ::  G22(elem2D%Np,lmesh2D%Ne)
+    real(RP), intent(in) ::  GsqrtH(elem2D%Np,lmesh2D%Ne)
+    real(RP), intent(in) :: gam(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  G13(elem%Np*lmesh%NeA)
+    real(RP), intent(in) ::  G23(elem%Np*lmesh%NeA)
+    real(RP), intent(in) :: nx(elem%NfpTot,lmesh%Ne)
+    real(RP), intent(in) :: ny(elem%NfpTot,lmesh%Ne)
+    real(RP), intent(in) :: nz(elem%NfpTot,lmesh%Ne)
+    integer, intent(in) :: vmapM(elem%NfpTot,lmesh%Ne)
+    integer, intent(in) :: vmapP(elem%NfpTot,lmesh%Ne)
+    integer, intent(in) :: iM2Dto3D(elem%NfpTot)
+    
+    integer :: ke, kp, iP(elem%NfpTot), iM(elem%NfpTot)
+    integer :: ke2D
+    real(RP) :: VelP(elem%NfpTot), VelM(elem%NfpTot), alpha(elem%NfpTot)
+    real(RP) :: dpresP(elem%NfpTot), dpresM(elem%NfpTot)
+    real(RP) :: GsqrtDensM(elem%NfpTot), GsqrtDensP(elem%NfpTot)
+    real(RP) :: GsqrtRhotM(elem%NfpTot), GsqrtRhotP(elem%NfpTot)
+    real(RP) :: GsqrtDDENS_P(elem%NfpTot), GsqrtDDENS_M(elem%NfpTot)
+    real(RP) :: GsqrtMOMX_P(elem%NfpTot), GsqrtMOMX_M(elem%NfpTot)
+    real(RP) :: GsqrtMOMY_P(elem%NfpTot), GsqrtMOMY_M(elem%NfpTot)
+    real(RP) :: GsqrtMOMZ_P(elem%NfpTot), GsqrtMOMZ_M(elem%NfpTot)
+    real(RP) :: GsqrtDRHOT_P(elem%NfpTot), GsqrtDRHOT_M(elem%NfpTot)
+    real(RP) :: Phyd_P(elem%NfpTot), Phyd_M(elem%NfpTot)
+    real(RP) :: Gsqrt_P(elem%NfpTot), Gsqrt_M(elem%NfpTot)
+    real(RP) :: GsqrtV_P(elem%NfpTot), GsqrtV_M(elem%NfpTot)
+    real(RP) :: G13_M(elem%NfpTot), G13_P(elem%NfpTot)
+    real(RP) :: G23_M(elem%NfpTot), G23_P(elem%NfpTot)
+    real(RP) :: G1n_M(elem%NfpTot), G2n_M(elem%NfpTot)
+    real(RP) :: Gnn_M(elem%NfpTot), Gnn_P(elem%NfpTot)
+    real(RP) :: Gxz_M(elem%NfpTot), Gxz_P(elem%NfpTot)
+    real(RP) :: Gyz_M(elem%NfpTot), Gyz_P(elem%NfpTot)
+    real(RP) :: rgam2_M(elem%NfpTot), rgam2_P(elem%NfpTot)
+
+    real(RP) :: gamm, rgamm    
+    real(RP) :: rP0
+    real(RP) :: RovP0, P0ovR
+
+    !------------------------------------------------------------------------
+
+    gamm  = CPDry / CvDry
+    rgamm = CvDry / CpDry
+    rP0   = 1.0_RP / PRES00
+    RovP0 = Rdry * rP0
+    P0ovR = PRES00 / Rdry
+
+    !if(PRC_GLOBAL_myrank == 0) then
+    !  write(*,*) "lmesh.NeA", lmesh%NeA
+    !  write(*,*) "lmesh.NeS", lmesh%NeS
+    !  write(*,*) "lmesh.NeE", lmesh%NeE
+    !  write(*,*) "lmesh2D.Ne", lmesh2D%Ne
+    !  write(*,*) "elem.NfpTot", elem%NfpTot
+    !end if
+
+    !$omp parallel do private( &
+    !$omp ke, kp, iM, iP, ke2D,                                                             &
+    !$omp alpha, VelM, VelP,                                                            &
+    !$omp dpresM, dpresP, GsqrtDensM, GsqrtDensP, GsqrtRhotM, GsqrtRhotP,               &
+    !$omp GsqrtMOMX_M, GsqrtMOMX_P, GsqrtMOMY_M, GsqrtMOMY_P, GsqrtMOMZ_M, GsqrtMOMZ_P, &
+    !$omp GsqrtDDENS_M, GsqrtDDENS_P, GsqrtDRHOT_M, GsqrtDRHOT_P,                       &
+    !$omp Phyd_M, Phyd_P,                                                               &
+    !$omp Gsqrt_P, Gsqrt_M, GsqrtV_P, GsqrtV_M, G13_P, G13_M, G23_P, G23_M,             &
+    !$omp rgam2_M, rgam2_P, Gxz_P, Gxz_M, Gyz_P, Gyz_M, G1n_M, G2n_M, Gnn_P, Gnn_M      )
+    do ke=lmesh%NeS, lmesh%NeE
+      iM(:) = vmapM(:,ke); iP(:) = vmapP(:,ke)
+      ke2D = lmesh%EMap3Dto2D(ke)
+
+      do kp=1, elem%NfpTot
+        G13_M(kp) = G13(iM(kp))
+        G13_P(kp) = G13(iP(kp))
+      end do
+      do kp=1, elem%NfpTot
+        G23_M(kp) = G23(iM(kp))
+        G23_P(kp) = G23(iP(kp))
+      end do
+
+      do kp=1, elem%NfpTot
+        Gsqrt_M(kp) = Gsqrt(iM(kp))
+        Gsqrt_P(kp) = Gsqrt(iP(kp))
+      end do
+
+      do kp=1, elem%NfpTot
+        rgam2_M(kp) = 1.0_RP / gam(iM(kp))**2
+        rgam2_P(kp) = 1.0_RP / gam(iP(kp))**2
+      end do
+
+      do kp=1, elem%NfpTot
+        GsqrtV_M(kp) = Gsqrt_M(kp) * rgam2_M(kp) / GsqrtH(iM2Dto3D(kp),ke2D)
+        GsqrtV_P(kp) = Gsqrt_P(kp) * rgam2_P(kp) / GsqrtH(iM2Dto3D(kp),ke2D)
+      end do
+
+      do kp=1, elem%NfpTot
+        Gxz_M(kp) = rgam2_M(kp) * ( G11(iM2Dto3D(kp),ke2D) * G13_M(kp) + G12(iM2Dto3D(kp),ke2D) * G23_M(kp) )
+        Gxz_P(kp) = rgam2_P(kp) * ( G11(iM2Dto3D(kp),ke2D) * G13_P(kp) + G12(iM2Dto3D(kp),ke2D) * G23_P(kp) )
+      end do
+
+      do kp=1, elem%NfpTot
+        Gyz_M(kp) = rgam2_M(kp) * ( G12(iM2Dto3D(kp),ke2D) * G13_M(kp) + G22(iM2Dto3D(kp),ke2D) * G23_M(kp) )
+        Gyz_P(kp) = rgam2_P(kp) * ( G12(iM2Dto3D(kp),ke2D) * G13_P(kp) + G22(iM2Dto3D(kp),ke2D) * G23_P(kp) )
+      end do
+
+      do kp=1, elem%NfpTot
+        G1n_M(kp) = rgam2_M(kp) * ( G11(iM2Dto3D(kp),ke2D) * nx(kp,ke) + G12(iM2Dto3D(kp),ke2D) * ny(kp,ke) )
+        G2n_M(kp) = rgam2_P(kp) * ( G12(iM2Dto3D(kp),ke2D) * nx(kp,ke) + G22(iM2Dto3D(kp),ke2D) * ny(kp,ke) )
+      end do
+
+      do kp=1, elem%NfpTot
+        Gnn_M(kp)  = rgam2_M(kp) * ( G11(iM2Dto3D(kp),ke2D) * abs( nx(kp,ke) ) + G22(iM2Dto3D(kp),ke2D) * abs( ny(kp,ke) ) ) &
+                  + ( 1.0_RP / GsqrtV_M(kp)**2 + G13_M(kp) * Gxz_M(kp) + G23_M(kp) * Gyz_M(kp) ) * abs( nz(kp,ke) )
+        Gnn_P(kp)  = rgam2_P(kp) * ( G11(iM2Dto3D(kp),ke2D) * abs( nx(kp,ke) ) + G22(iM2Dto3D(kp),ke2D) * abs( ny(kp,ke) ) ) &
+                  + ( 1.0_RP / GsqrtV_P(kp)**2 + G13_P(kp) * Gxz_P(kp) + G23_P(kp) * Gyz_P(kp) ) * abs( nz(kp,ke) )
+      end do
+
+      do kp=1, elem%NfpTot
+        GsqrtDDENS_M(kp) = Gsqrt_M(kp) * DDENS_(iM(kp))
+        GsqrtMOMX_M (kp) = Gsqrt_M(kp) * MOMX_ (iM(kp))
+        GsqrtMOMY_M (kp) = Gsqrt_M(kp) * MOMY_ (iM(kp))
+        GsqrtMOMZ_M (kp) = Gsqrt_M(kp) * MOMZ_ (iM(kp))
+        GsqrtDRHOT_M(kp) = Gsqrt_M(kp) * DRHOT_(iM(kp))
+      end do
+
+      do kp=1, elem%NfpTot
+        GsqrtDDENS_P(kp) = Gsqrt_P(kp) * DDENS_(iP(kp))
+        GsqrtMOMX_P (kp) = Gsqrt_P(kp) * MOMX_ (iP(kp))
+        GsqrtMOMY_P (kp) = Gsqrt_P(kp) * MOMY_ (iP(kp))
+        GsqrtMOMZ_P (kp) = Gsqrt_P(kp) * MOMZ_ (iP(kp))
+        GsqrtDRHOT_P(kp) = Gsqrt_P(kp) * DRHOT_(iP(kp))
+      end do
+
+      do kp=1, elem%NfpTot
+        Phyd_M(kp) = PRES_hyd(iM(kp))
+        Phyd_P(kp) = PRES_hyd(iP(kp))
+      end do
+
+      do kp=1, elem%NfpTot
+        GsqrtDensM(kp) = GsqrtDDENS_M(kp) + Gsqrt_M(kp) * DENS_hyd(iM(kp))
+        GsqrtDensP(kp) = GsqrtDDENS_P(kp) + Gsqrt_P(kp) * DENS_hyd(iP(kp))
+      end do
+
+
+      do kp=1, elem%NfpTot
+        GsqrtRhotM(kp) = Gsqrt_M(kp) * P0ovR * (Phyd_M(kp) * rP0)**rgamm + GsqrtDRHOT_M(kp)
+      end do
+
+      do kp=1, elem%NfpTot
+        GsqrtRhotP(kp) = Gsqrt_P(kp) * P0ovR * (Phyd_P(kp) * rP0)**rgamm + GsqrtDRHOT_P(kp)
+      end do
+
+      do kp=1, elem%NfpTot
+        VelM(kp) = ( GsqrtMOMX_M(kp) * nx(kp,ke) + GsqrtMOMY_M(kp) * ny(kp,ke)                    &
+                  + ( ( GsqrtMOMZ_M(kp) / GsqrtV_M(kp)                                         &
+                      + G13_M(kp) * GsqrtMOMX_M(kp) + G23_M(kp) * GsqrtMOMY_M(kp) ) * nz(kp,ke) ) &
+                  ) / GsqrtDensM(kp)
+      end do
+
+      do kp=1, elem%NfpTot
+        VelP(kp) = ( GsqrtMOMX_P(kp) * nx(kp,ke) + GsqrtMOMY_P(kp) * ny(kp,ke)                    &
+                  + ( ( GsqrtMOMZ_P(kp) / GsqrtV_P(kp)                                         &
+                      + G13_P(kp) * GsqrtMOMX_P(kp) + G23_P(kp) * GsqrtMOMY_P(kp) ) * nz(kp,ke) ) &
+                  ) / GsqrtDensP(kp)
+      end do
+
+      ! dpresM(:) = PRES00 * ( Rtot(iM) * rP0 * GsqrtRhotM(:) / Gsqrt_M(:) )**( CPtot(iM) / CVtot(iM) ) &
+      !           - Phyd_M(:)
+      ! dpresP(:) = PRES00 * ( Rtot(iP) * rP0 * GsqrtRhotP(:) / Gsqrt_P(:) )**( CPtot(iP) / CVtot(iP) ) &
+      !           - Phyd_P(:)
+      do kp=1, elem%NfpTot
+        dpresM(kp) = DPRES_(iM(kp))
+        dpresP(kp) = DPRES_(iP(kp))
+      end do
+
+      do kp=1, elem%NfpTot
+        alpha(kp) = max( sqrt( Gnn_M(kp) * gamm * ( Phyd_M(kp) + dpresM(kp) ) * Gsqrt_M(kp) / GsqrtDensM(kp) ) + abs(VelM(kp)), &
+                        sqrt( Gnn_P(kp) * gamm * ( Phyd_P(kp) + dpresP(kp) ) * Gsqrt_P(kp) / GsqrtDensP(kp) ) + abs(VelP(kp))  )
+      end do
+
+      do kp=1, elem%NfpTot
+        del_flux(kp,ke,DENS_VID) = 0.5_RP * ( &
+                      ( GsqrtDensP(kp) * VelP(kp) - GsqrtDensM(kp) * VelM(kp) )  &
+                      - alpha(kp) * ( GsqrtDDENS_P(kp) - GsqrtDDENS_M(kp) )     )
+      end do
+
+      do kp=1, elem%NfpTot
+        del_flux(kp,ke,MOMX_VID ) = 0.5_RP * ( &
+                      ( GsqrtMOMX_P(kp) * VelP(kp) - GsqrtMOMX_M(kp) * VelM(kp) )           &
+                      + (  Gsqrt_P(kp) * ( G1n_M(kp) + Gxz_P(kp) * nz(kp,ke)) * dpresP(kp)   &
+                        - Gsqrt_M(kp) * ( G1n_M(kp) + Gxz_M(kp) * nz(kp,ke)) * dpresM(kp) ) &
+                      - alpha(kp) * ( GsqrtMOMX_P(kp) - GsqrtMOMX_M(kp) )                  )
+      end do
+
+      do kp=1, elem%NfpTot
+        del_flux(kp,ke,MOMY_VID ) = 0.5_RP * ( &
+                      ( GsqrtMOMY_P(kp) * VelP(kp) - GsqrtMOMY_M(kp) * VelM(kp) )            &
+                      + (  Gsqrt_P(kp) * ( G2n_M(kp) + Gyz_P(kp) * nz(kp,ke) ) * dpresP(kp)   &
+                        - Gsqrt_M(kp) * ( G2n_M(kp) + Gyz_M(kp) * nz(kp,ke) ) * dpresM(kp) ) &
+                      - alpha(kp) * ( GsqrtMOMY_P(kp) - GsqrtMOMY_M(kp) )        )
+      end do
+      
+      do kp=1, elem%NfpTot
+          del_flux(kp,ke,MOMZ_VID ) = 0.5_RP * ( &
+                        ( GsqrtMOMZ_P(kp) * VelP(kp) - GsqrtMOMZ_M(kp) * VelM(kp) ) &
+                        + (  Gsqrt_P(kp) * dpresP(kp) / GsqrtV_P(kp)               &
+                          - Gsqrt_M(kp) * dpresM(kp) / GsqrtV_M(kp) ) * nz(kp,ke)  &
+                        - alpha(kp) * ( GsqrtMOMZ_P(kp) - GsqrtMOMZ_M(kp) )        )
+      end do
+                    
+      do kp=1, elem%NfpTot
+        del_flux(kp,ke,RHOT_VID) = 0.5_RP * ( &
+                      ( GsqrtRhotP(kp) * VelP(kp) - GsqrtRhotM(kp) * VelM(kp) )   &
+                      - alpha(kp) * ( GsqrtDRHOT_P(kp) - GsqrtDRHOT_M(kp) )      )
+      end do
+
+      do kp=1, elem%NfpTot
+        del_flux_hyd(kp,ke,1) = 0.5_RP * ( &
+            GsqrtV_P(kp) * ( nx(kp,ke) + G13_P(kp) * nz(kp,ke) ) * Phyd_P(kp) &
+          - GsqrtV_M(kp) * ( nx(kp,ke) + G13_M(kp) * nz(kp,ke) ) * Phyd_M(kp) )
+      end do
+      
+      do kp=1, elem%NfpTot
+        del_flux_hyd(kp,ke,2) = 0.5_RP * ( &
+            GsqrtV_P(kp) * ( ny(kp,ke) + G23_P(kp) * nz(kp,ke) ) * Phyd_P(kp) &
+          - GsqrtV_M(kp) * ( ny(kp,ke) + G23_M(kp) * nz(kp,ke) ) * Phyd_M(kp) )
+      end do
+    end do
+
+    return
+  end subroutine atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_get_generalhvc
+
+end module scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux

--- a/FElib/test/FE/modal_filter/Makefile
+++ b/FElib/test/FE/modal_filter/Makefile
@@ -30,11 +30,11 @@ makedir:
 makebin: $(BINNAME)
 	@echo "Complete making."
 
-run:
-	mpirun -n 1 ./$(BINNAME)
-
-vis:
-	bash ./visualize/visualize.sh
+#run:
+#	mpirun -n 1 ./$(BINNAME)
+#
+#vis:
+#	bash ./visualize/visualize.sh
 
 $(BINNAME): $(BUILD_DIR)/$(BINNAME).o $(patsubst %,$(BUILD_DIR)/%,$(OBJS)) $(LIBS)
 	$(LD) $(LDFLAGS) $(ADDITIONAL_FFLAGS) -o $@ $^ $(LIBS) $(CONTRIB_LIBS) $(SCALE_NETCDF_LIBS) $(SCALE_MATHLIB_LIBS) $(SCALE_PAPI_LIBS)

--- a/FElib/test/FE/modal_filter/Makefile
+++ b/FElib/test/FE/modal_filter/Makefile
@@ -22,7 +22,6 @@ all:
 	$(MAKE) envlog
 	$(MAKE) makedir
 	$(MAKE) makebin
-	$(MAKE) run
 
 makedir:
 	mkdir -p $(BUILD_DIR)

--- a/FElib/test/FE/modal_filter/Makefile
+++ b/FElib/test/FE/modal_filter/Makefile
@@ -1,0 +1,61 @@
+################################################################################
+#
+# Makefile for each test program
+#
+################################################################################
+
+PWD         = $(shell pwd)
+TOPDIR      = $(abspath ../../../..)
+BUILD_DIR   = ./.libs
+SYSDEP_DIR  = $(TOPDIR)/sysdep
+
+include $(SYSDEP_DIR)/Makedef.$(SCALE_FE_SYS)
+include $(TOPDIR)/Mkinclude
+
+BINNAME = test_modalfilter
+
+LIBS = $(LIBDIR)/libScaleFECore.a
+
+OBJS =
+
+all:
+	$(MAKE) envlog
+	$(MAKE) makedir
+	$(MAKE) makebin
+	$(MAKE) run
+
+makedir:
+	mkdir -p $(BUILD_DIR)
+
+makebin: $(BINNAME)
+	@echo "Complete making."
+
+run:
+	mpirun -n 1 ./$(BINNAME)
+
+vis:
+	bash ./visualize/visualize.sh
+
+$(BINNAME): $(BUILD_DIR)/$(BINNAME).o $(patsubst %,$(BUILD_DIR)/%,$(OBJS)) $(LIBS)
+	$(LD) $(LDFLAGS) $(ADDITIONAL_FFLAGS) -o $@ $^ $(LIBS) $(CONTRIB_LIBS) $(SCALE_NETCDF_LIBS) $(SCALE_MATHLIB_LIBS) $(SCALE_PAPI_LIBS)
+
+$(BUILD_DIR)/$(BINNAME).o: $(BINNAME).f90 $(patsubst %,$(BUILD_DIR)/%,$(OBJS))
+
+distclean: clean
+	rm -f $(BINNAME)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+.SUFFIXES:
+.SUFFIXES: .o .f90 .mod
+
+%.mod: %.f90
+	$(MAKE) $(patsubst %.f90,%.o,$<)
+
+$(BUILD_DIR)/%.o: %.f90
+	$(FC) $(FFLAGS) $(ADDITIONAL_FFLAGS) -DVERSION_MACRO=\"$(VERSION)\" -I$(BUILD_DIR) -I$(MODDIR) $(CONTRIB_INCLUDE) -I$(SCALEFELIBDIR)/include  $(SCALE_NETCDF_INCLUDE) $(MODDIROPT) $(BUILD_DIR) -o $@ -c $<
+
+.PHONY : clean distclean allclean
+
+include $(TOPDIR)/utils/make/Make_environments

--- a/FElib/test/FE/modal_filter/test_modalfilter.f90
+++ b/FElib/test/FE/modal_filter/test_modalfilter.f90
@@ -87,7 +87,7 @@ contains
                                filterMat(i,5) * q_in(5,j,k) + & 
                                filterMat(i,6) * q_in(6,j,k) + & 
                                filterMat(i,7) * q_in(7,j,k) + & 
-                               filterMat(i,8) * q_in(8,j,k) + & 
+                               filterMat(i,8) * q_in(8,j,k) 
         end do
         end do
         end do
@@ -103,7 +103,7 @@ contains
                           q_out_new(i,5,k) * filterMat_tr(5,j) + &
                           q_out_new(i,6,k) * filterMat_tr(6,j) + &
                           q_out_new(i,7,k) * filterMat_tr(7,j) + &
-                          q_out_new(i,8,k) * filterMat_tr(8,j) + &
+                          q_out_new(i,8,k) * filterMat_tr(8,j)
         end do
         end do
         end do
@@ -119,7 +119,7 @@ contains
                                q_in(i,j,5) * filterMat_tr(5,k) + & 
                                q_in(i,j,6) * filterMat_tr(6,k) + & 
                                q_in(i,j,7) * filterMat_tr(7,k) + & 
-                               q_in(i,j,8) * filterMat_tr(8,k) + & 
+                               q_in(i,j,8) * filterMat_tr(8,k)
         end do
         end do
         end do

--- a/FElib/test/FE/modal_filter/test_modalfilter.f90
+++ b/FElib/test/FE/modal_filter/test_modalfilter.f90
@@ -19,6 +19,7 @@ program test_modalfilter
     real(RP) :: q_in(Np)
     real(RP) :: q_out_ori(Np)
     real(RP) :: q_out_new(Np)
+    real(RP) :: error(Np)
     real(RP) :: rmse
 
     real(RP) :: filter1D_tr(Np1D, Np1D)
@@ -46,14 +47,15 @@ program test_modalfilter
 
     call apply_filter_xyz(filter1D%FilterMat, filter1D_tr, q_in, q_out_new)
 
-    print *, "q original"
+    !-- calculate error: err = q_out_new - q_out_ori 
     do kp=1, Np
-        print *, q_out_ori(kp)
+        error(kp) = q_out_new(kp) - q_out_ori(kp)
     end do
-    print *, "q new"
-    do kp=1, Np
-        print *, q_out_new(kp)
-    end do
+
+    !-- save error
+    open(10, file="modalfilter_err.dat", access='stream', form='unformatted', status='new')
+    write(10) error(:)
+    close(10)
 
     !-- calculate rmse
     do kp=1, Np

--- a/FElib/test/FE/modal_filter/test_modalfilter.f90
+++ b/FElib/test/FE/modal_filter/test_modalfilter.f90
@@ -1,0 +1,128 @@
+#include "scalelib.h"
+program test_modalfilter
+    use scale_precision
+    use scale_element_line
+    use scale_element_hexahedral
+    use scale_element_modalfilter
+    implicit none
+
+    type(LineElement) :: elem1D
+    type(HexahedralElement) :: elem
+    type(ModalFilter) :: filter
+    type(ModalFilter) :: filter1D
+
+    integer, parameter :: porder=7
+    integer, parameter :: Np1D=porder+1
+    integer, parameter :: Np=(porder+1)**3
+
+    integer :: x, y, z, kp
+    real(RP) :: q_in(Np)
+    real(RP) :: q_out_ori(Np)
+    real(RP) :: q_out_new(Np)
+    real(RP) :: rmse
+
+    real(RP) :: filter1D_tr(Np1D, Np1D)
+
+    call elem%Init(porder, porder, .false.)
+    call elem1D%Init(porder, .false.)
+
+    call filter%Init(elem, 0D0, 0D0, 16, 0D0, 0D0, 16)
+    call filter1D%Init(elem1D, 0D0, 0D0, 16)
+
+    filter1D_tr(:,:) = transpose(filter1D%FilterMat(:,:))
+
+    do z = 1, 8
+    do y = 1, 8
+    do x = 1, 8
+        kp = x + (y - 1) * 8 + (z - 1) * 8 * 8
+        q_in(kp) = sin(x) * sin(y) * sin(z) 
+    end do
+    end do
+    end do
+
+    q_out_ori(:) = matmul(filter%FilterMat, q_in)
+
+    q_out_new(:) = 0.0_RP
+
+    call apply_filter_xyz(filter1D%FilterMat, filter1D_tr, q_in, q_out_new)
+
+    print *, "q original"
+    do kp=1, Np
+        print *, q_out_ori(kp)
+    end do
+    print *, "q new"
+    do kp=1, Np
+        print *, q_out_new(kp)
+    end do
+
+    !-- calculate rmse
+    do kp=1, Np
+        rmse = rmse + (q_out_new(kp) - q_out_ori(kp)) ** 2
+    end do
+
+    rmse = sqrt(rmse / Np)
+
+    print *, "RMSE: ", rmse
+        
+   
+contains
+    subroutine apply_filter_xyz(filterMat, filterMat_tr, q_in, q_out_new)
+        implicit none
+
+        real(RP), intent(in) :: filterMat(8, 8)
+        real(RP), intent(in) :: filterMat_tr(8, 8)
+        real(RP), intent(inout) :: q_in(8,8,8)
+        real(RP), intent(inout) :: q_out_new(8,8,8)
+
+        integer :: i, j, k
+
+        !-- x direction
+        do k=1, 8
+        do j=1, 8
+        do i=1, 8
+            q_out_new(i,j,k) = filterMat(i,1) * q_in(1,j,k) + &
+                               filterMat(i,2) * q_in(2,j,k) + & 
+                               filterMat(i,3) * q_in(3,j,k) + & 
+                               filterMat(i,4) * q_in(4,j,k) + & 
+                               filterMat(i,5) * q_in(5,j,k) + & 
+                               filterMat(i,6) * q_in(6,j,k) + & 
+                               filterMat(i,7) * q_in(7,j,k) + & 
+                               filterMat(i,8) * q_in(8,j,k) + & 
+        end do
+        end do
+        end do
+
+        !-- y direction
+        do k=1, 8
+        do j=1, 8
+        do i=1, 8
+            q_in(i,j,k) = q_out_new(i,1,k) * filterMat_tr(1,j) + &
+                          q_out_new(i,2,k) * filterMat_tr(2,j) + &
+                          q_out_new(i,3,k) * filterMat_tr(3,j) + &
+                          q_out_new(i,4,k) * filterMat_tr(4,j) + &
+                          q_out_new(i,5,k) * filterMat_tr(5,j) + &
+                          q_out_new(i,6,k) * filterMat_tr(6,j) + &
+                          q_out_new(i,7,k) * filterMat_tr(7,j) + &
+                          q_out_new(i,8,k) * filterMat_tr(8,j) + &
+        end do
+        end do
+        end do
+
+        !-- z direction
+        do k=1, 8
+        do j=1, 8
+        do i=1, 8
+            q_out_new(i,j,k) = q_in(i,j,1) * filterMat_tr(1,k) + &
+                               q_in(i,j,2) * filterMat_tr(2,k) + & 
+                               q_in(i,j,3) * filterMat_tr(3,k) + & 
+                               q_in(i,j,4) * filterMat_tr(4,k) + & 
+                               q_in(i,j,5) * filterMat_tr(5,k) + & 
+                               q_in(i,j,6) * filterMat_tr(6,k) + & 
+                               q_in(i,j,7) * filterMat_tr(7,k) + & 
+                               q_in(i,j,8) * filterMat_tr(8,k) + & 
+        end do
+        end do
+        end do
+
+    end subroutine apply_filter_xyz
+end program test_modalfilter

--- a/FElib/test/FE/modal_filter/test_modalfilter.f90
+++ b/FElib/test/FE/modal_filter/test_modalfilter.f90
@@ -35,7 +35,7 @@ program test_modalfilter
     do y = 1, 8
     do x = 1, 8
         kp = x + (y - 1) * 8 + (z - 1) * 8 * 8
-        q_in(kp) = sin(x) * sin(y) * sin(z) 
+        q_in(kp) = sin(dble(x)) * sin(dble(y)) * sin(dble(z)) 
     end do
     end do
     end do

--- a/set_scale_env.sh
+++ b/set_scale_env.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#----------- install module -------------
+module load netcdf-c
+module load netcdf-fortran
+module load parallel-netcdf
+module load phdf5
+
+module load python/3.8.12
+module load py-numpy
+module load py-matplotlib
+
+#---- Echo my work dir ----
+echo "My work directory: ${WORK_DIR}"
+
+#------------ setup environment variables ---------
+export SCALE=${WORK_DIR}/scale-5.4.5
+export SCALE_FE=${WORK_DIR}/FE-Project
+export SCALE_ENABLE_OPENMP=T
+export SCALE_FE_SYS=FLOW
+export SCALE_SYS=FLOW
+export FE_SRC=$SCALE_FE/FElib/src
+
+#---------- print out enviroment variables -----
+echo $SCALE
+echo $SCALE_FE
+echo $SCALE_FE_SYS
+echo $SCALE_SYS
+

--- a/sysdep/Makedef.FLOW
+++ b/sysdep/Makedef.FLOW
@@ -1,0 +1,116 @@
+################################################################################
+#
+# ------ For FUGAKU -----
+#
+################################################################################
+
+##### Fortran setting
+#FFLAGS is set in Mkinclude. FFLAGS_DEBUG is used if SCALE_DEBUG=T
+
+FC  = mpifrtpx
+SFC = frtpx
+MODDIROPT = -M
+
+FFLAGS_FAST  = -Kfast,parallel,ocl,preex,array_private,noalias=s,mfunc=2 \
+               -Nlst=i,lst=t -X08 -Ncompdisp -Koptmsg=1 -Cpp             \
+               -x-                                                       \
+               -Ksimd,loop_fission                                       \
+               -Kauto,threadsafe                                         \
+               -Nfjomplib                                                \
+               -Koptlib_string                                           \
+               -DVECTLEN=${VECTLEN} -DCACHELINESIZE=${CACHELINESIZE}            
+
+FFLAGS_AGGRESSIVE = -Kinstance=12,swp_strong
+
+FFLAGS_QUICKDEBUG = -Nquickdbg -NRtrap
+
+FFLAGS_DYN   = $(FFLAGS) -Knoprefetch,loop_nofission,loop_nofusion,nounroll,parallel_strong -Ksimd=2 -x100
+
+FFLAGS_DEBUG = -O0                                                       \
+               -Nlst=i,lst=t -X03 -v03s -v03d -v03o -Ncompdisp -Koptmsg=1 -Cpp \
+               -Ec -Eg -Ha -He -Hf -Ho -Hs -Hu -Hx -Ncheck_global
+
+
+
+##### C setting
+#CFLAGS is set in Mkinclude. CFLAGS_DEBUG is used if SCALE_DEBUG=T
+
+CC = mpifccpx
+
+CFLAGS_FAST  = -Kfast,parallel,ocl,preex,array_private,region_extension,restp=all -Ksimd
+CFLAGS_DEBUG = -O0
+
+##### Vector length
+ifeq ($(SCALE_USE_SINGLEFP),T)
+   VECTLEN = 16
+else
+   VECTLEN = 8
+endif
+CACHELINESIZE = 256
+
+##### Special setting
+
+FFLAGS_OPENMP = -Kopenmp
+# enable + disable parallel
+# FFLAGS_OPENMP = -Kopenmp,noparallel
+
+### Performance monitor
+# disable
+#PERF_MONIT = -Nnofjprof -UFIPP -UFAPP -UFINEPA
+# fipp
+PERF_MONIT = -Nfjprof -DFIPP -UFAPP -UFINEPA
+# fapp
+PERF_MONIT = -Nfjprof -UFIPP -DFAPP -UFINEPA
+# fine PA
+#PERF_MONIT = -Nfjprof -UFIPP -UFAPP -DFINEPA
+
+FFLAGS_SYSDEPEND = $(PERF_MONIT)
+CFLAGS_SYSDEPEND = $(PERF_MONIT)
+
+
+
+##### Linker setting
+
+LD      = $(FC)
+LDFLAGS = $(FFLAGS)
+
+
+
+################################################################################
+
+###### NetCDF library
+# Default settings
+# if nc-config is not available, please set environment variable
+# example:
+# export SCALE_NETCDF_INCLUDE="-I/home/user/tool/cross-K/include"
+# export SCALE_NETCDF_LIBS="-L/home/user/tool/cross-K/lib -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -lsz -lz"
+
+#NC_HASH = $(shell spack find -lx netcdf-c%fj | grep netcdf-c | awk '{print $$1}')
+#NF_HASH = $(shell spack find -lx netcdf-fortran%fj | grep netcdf-fortran | awk '{print $$1}')
+#HDF_HASH = $(shell spack find -l --deps /${NC_HASH} | grep hdf5 | awk '{print $$1}')
+SCALE_NETCDF_C = /home/center/opt/spack/aarch64/fj/4.2.1/netcdf-c/4.7.4
+SCALE_NETCDF_F = /home/center/opt/spack/aarch64/fj/4.2.1/netcdf-fortran/4.5.3
+SCALE_PNETCDF = /home/center/opt/spack/aarch64/fj/4.1.0/parallel-netcdf/1.12.1/5n5
+SCALE_HDF = /home/center/opt/spack/aarch64/fj/4.2.1/phdf5/1.10.7
+SCALE_NETCDF_INCLUDE ?= -I$(SCALE_NETCDF_C)/include -I$(SCALE_NETCDF_F)/include
+SCALE_NETCDF_LIBS ?= -L$(SCALE_NETCDF_C)/lib -L$(SCALE_NETCDF_F)/lib -L$(SCALE_HDF)/lib -L$(SCALE_PNETCDF)/lib -lpnetcdf -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -lfjprofmpi -lmpi_cxx
+SCALE_ENABLE_PNETCDF ?= T
+
+
+###### Math library
+# Default settings
+SCALE_MATHLIB_LIBS ?=
+# Or, please set environment variable
+# example:
+export SCALE_MATHLIB_LIBS="-SSL2"
+
+##### SCALE
+SCALEORI_INCLUDE  ?= -I$(SCALE)/include -I$(SCALE)/scalelib/include
+SCALEORI_LIBS     ?= -L$(SCALE)/lib -lscale -ldcutils
+
+##### for frontend
+INSTALL = install
+AR      = ar
+ARFLAGS = r
+RANLIB  = ranlib
+JOBSUB  = pjsub


### PR DESCRIPTION
### New scripts and makedef files

1. Add environment variables setup script: set_scale_env.sh
2. Add new Makedef for FLOW supercomputer at sys/Makedef.FLOW

### Optimization codes of modalfilter
New and modified files:

1. FElib/src/element/scale_element_modalfilter.F90 (is same as scale_element_modalfilter_tune1.F90)
2. FElib/src/element/scale_element_modalfilter_orig.F90
3. FElib/src/element/scale_element_modalfilter_tune1.F90 
4. FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter.F90 (is same as scale_atm_dyn_dgm_modalfilter_tune3_p11.F90)
5. FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_orig.F90
6. FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune_p7.F90
7. FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune_p11.F90
8. FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune2_p11.F90
9. FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_modalfilter_tune3_p11.F90
10. New unit test at FElib/test/FE/modal_filter

### Optimization codes of numerical flux
New and modified files:

1. FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux.F90 (the original version)
2. FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_orig.F90 (the original version backup)
3. FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_nonhydro3d_rhot_heve_numflux_tune1.F90 (Implementing with do loop instead of array substitution)

### Optimization codes of calc_tend
New and modified files:
1. FElib/src/common/scale_sparsemat.F90 (the original version)
2. FElib/src/common/scale_sparsemat_orig.F90 (the original version backup)
3. FElib/src/common/scale_sparsemat_tune1.F90 (computing multiple vertors at 1 time)
4. FElib/src/common/scale_sparsemat_tune2.F90 (based on tune1, switch indexes of array b)
5. FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve.F90 (the original version)
6. FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve_orig.F90 (the original version backup)
7. FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve_tune1.F90 (computing multiple vertors at 1 time)
8. FElib/src/fluid_dyn_solver/scale_atm_dyn_dgm_globalnonhydro3d_rhot_heve_tune2.F90 (based on tune1, switch indexes of array wk)